### PR TITLE
Add DP-aware routing support to KVEvents and indexing pipeline

### DIFF
--- a/api/indexerpb/indexer.pb.go
+++ b/api/indexerpb/indexer.pb.go
@@ -21,11 +21,12 @@
 package indexerpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -141,11 +142,20 @@ func (x *GetPodScoresResponse) GetScores() []*PodScore {
 }
 
 type PodScore struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Pod           string                 `protobuf:"bytes,1,opt,name=pod,proto3" json:"pod,omitempty"`
-	Score         float64                `protobuf:"fixed64,2,opt,name=score,proto3" json:"score,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Pod   string                 `protobuf:"bytes,1,opt,name=pod,proto3" json:"pod,omitempty"`
+	Score float64                `protobuf:"fixed64,2,opt,name=score,proto3" json:"score,omitempty"`
+	// Data parallel rank for this pod. The field is `optional`, so callers
+	// MUST distinguish "not set" from "set to 0":
+	//   - Not set (absent)  => non-DP deployment. In Go, DataParallelRank == nil.
+	//   - Set to 0          => DP deployment, rank 0. In Go, *DataParallelRank == 0.
+	//   - Set to N > 0      => DP deployment, zero-based rank N.
+	// Do NOT treat the zero value as "absent". The `pod` field always contains
+	// the base pod identifier (e.g. "pod-1"); the rank is carried separately so
+	// routing decisions can key on (pod, rank) without string parsing.
+	DataParallelRank *int32 `protobuf:"varint,3,opt,name=data_parallel_rank,json=dataParallelRank,proto3,oneof" json:"data_parallel_rank,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *PodScore) Reset() {
@@ -192,6 +202,13 @@ func (x *PodScore) GetScore() float64 {
 	return 0
 }
 
+func (x *PodScore) GetDataParallelRank() int32 {
+	if x != nil && x.DataParallelRank != nil {
+		return *x.DataParallelRank
+	}
+	return 0
+}
+
 var File_api_indexerpb_indexer_proto protoreflect.FileDescriptor
 
 const file_api_indexerpb_indexer_proto_rawDesc = "" +
@@ -204,10 +221,12 @@ const file_api_indexerpb_indexer_proto_rawDesc = "" +
 	"model_name\x18\x02 \x01(\tR\tmodelName\x12'\n" +
 	"\x0fpod_identifiers\x18\x03 \x03(\tR\x0epodIdentifiers\"D\n" +
 	"\x14GetPodScoresResponse\x12,\n" +
-	"\x06scores\x18\x01 \x03(\v2\x14.indexer.v1.PodScoreR\x06scores\"2\n" +
+	"\x06scores\x18\x01 \x03(\v2\x14.indexer.v1.PodScoreR\x06scores\"|\n" +
 	"\bPodScore\x12\x10\n" +
 	"\x03pod\x18\x01 \x01(\tR\x03pod\x12\x14\n" +
-	"\x05score\x18\x02 \x01(\x01R\x05score2e\n" +
+	"\x05score\x18\x02 \x01(\x01R\x05score\x121\n" +
+	"\x12data_parallel_rank\x18\x03 \x01(\x05H\x00R\x10dataParallelRank\x88\x01\x01B\x15\n" +
+	"\x13_data_parallel_rank2e\n" +
 	"\x0eIndexerService\x12S\n" +
 	"\fGetPodScores\x12\x1f.indexer.v1.GetPodScoresRequest\x1a .indexer.v1.GetPodScoresResponse\"\x00B9Z7github.com/llm-d/llm-d-kv-cache/api/indexerpb;indexerpbb\x06proto3"
 
@@ -245,6 +264,7 @@ func file_api_indexerpb_indexer_proto_init() {
 	if File_api_indexerpb_indexer_proto != nil {
 		return
 	}
+	file_api_indexerpb_indexer_proto_msgTypes[2].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/api/indexerpb/indexer.proto
+++ b/api/indexerpb/indexer.proto
@@ -40,4 +40,13 @@ message GetPodScoresResponse {
 message PodScore {
   string pod = 1;
   double score = 2;
+  // Data parallel rank for this pod. The field is `optional`, so callers
+  // MUST distinguish "not set" from "set to 0":
+  //   - Not set (absent)  => non-DP deployment. In Go, DataParallelRank == nil.
+  //   - Set to 0          => DP deployment, rank 0. In Go, *DataParallelRank == 0.
+  //   - Set to N > 0      => DP deployment, zero-based rank N.
+  // Do NOT treat the zero value as "absent". The `pod` field always contains
+  // the base pod identifier (e.g. "pod-1"); the rank is carried separately so
+  // routing decisions can key on (pod, rank) without string parsing.
+  optional int32 data_parallel_rank = 3;
 }

--- a/api/indexerpb/indexer_grpc.pb.go
+++ b/api/indexerpb/indexer_grpc.pb.go
@@ -22,6 +22,7 @@ package indexerpb
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
+++ b/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
@@ -299,7 +299,7 @@ func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, request *types
 		if err != nil {
 			return nil, fmt.Errorf("failed to get pod scores for chat/completions: %w", err)
 		}
-		return scores, nil
+		return flattenScoresByPod(scores), nil
 	}
 
 	// For regular completions, use the prompt directly
@@ -311,8 +311,22 @@ func (s *PrecisePrefixCacheScorer) getScores(ctx context.Context, request *types
 		if err != nil {
 			return nil, fmt.Errorf("failed to get pod scores for completions: %w", err)
 		}
-		return scores, nil
+		return flattenScoresByPod(scores), nil
 	}
 
 	return nil, errors.New("no valid input found in request")
+}
+
+// flattenScoresByPod collapses the indexer's (pod, dp-rank)-keyed score map into
+// a plain pod-identifier-keyed map, keeping the highest score per pod. This
+// scorer routes on pod address only and is not DP-rank aware; DP-aware routing
+// happens on the scheduler side via the gRPC PodScore.data_parallel_rank field.
+func flattenScoresByPod(scores map[kvblock.PodEntry]float64) map[string]float64 {
+	flat := make(map[string]float64, len(scores))
+	for entry, score := range scores {
+		if cur, ok := flat[entry.PodIdentifier]; !ok || score > cur {
+			flat[entry.PodIdentifier] = score
+		}
+	}
+	return flat
 }

--- a/examples/kv_cache_index/main.go
+++ b/examples/kv_cache_index/main.go
@@ -143,7 +143,7 @@ func runPrompts(ctx context.Context, kvCacheIndexer *kvcache.Indexer) error {
 	requestKeys := engineKeys
 
 	if err := kvCacheIndexer.KVBlockIndex().Add(ctx, engineKeys, requestKeys,
-		[]kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}}); err != nil {
+		[]kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}}); err != nil {
 		return err
 	}
 

--- a/examples/kv_cache_index_service/server/server.go
+++ b/examples/kv_cache_index_service/server/server.go
@@ -53,12 +53,16 @@ func (s *IndexerService) GetPodScores(ctx context.Context,
 		return nil, fmt.Errorf("failed to get pod scores: %w", err)
 	}
 
-	// Convert map[string]int to []*indexerpb.PodScore
+	// Convert map[string]float64 to []*indexerpb.PodScore. Scoring keys are
+	// "pod-1" (non-DP) or "pod-1@dp0" (DP-aware); decomposition rules live in
+	// kvcache.ParsePodScoringKey so the server and scorer cannot drift apart.
 	scores := make([]*indexerpb.PodScore, 0, len(podScores))
-	for pod, score := range podScores {
+	for scoringKey, score := range podScores {
+		pod, dpRank := kvcache.ParsePodScoringKey(scoringKey)
 		scores = append(scores, &indexerpb.PodScore{
-			Pod:   pod,
-			Score: score,
+			Pod:              pod,
+			Score:            score,
+			DataParallelRank: dpRank,
 		})
 	}
 

--- a/examples/kv_cache_index_service/server/server.go
+++ b/examples/kv_cache_index_service/server/server.go
@@ -53,16 +53,14 @@ func (s *IndexerService) GetPodScores(ctx context.Context,
 		return nil, fmt.Errorf("failed to get pod scores: %w", err)
 	}
 
-	// Convert map[string]float64 to []*indexerpb.PodScore. Scoring keys are
-	// "pod-1" (non-DP) or "pod-1@dp0" (DP-aware); decomposition rules live in
-	// kvcache.ParsePodScoringKey so the server and scorer cannot drift apart.
+	// The score map is keyed by kvblock.PodEntry carrying the pod identifier and
+	// DP rank directly, so no string parsing is needed at the gRPC boundary.
 	scores := make([]*indexerpb.PodScore, 0, len(podScores))
-	for scoringKey, score := range podScores {
-		pod, dpRank := kvcache.ParsePodScoringKey(scoringKey)
+	for entry, score := range podScores {
 		scores = append(scores, &indexerpb.PodScore{
-			Pod:              pod,
+			Pod:              entry.PodIdentifier,
 			Score:            score,
-			DataParallelRank: dpRank,
+			DataParallelRank: entry.DataParallelRankPtr(),
 		})
 	}
 

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -233,6 +233,29 @@ func setupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) (*kvevents
 	return pool, nil
 }
 
+// podScoreJSON is a JSON-serializable view of a single pod score. The indexer
+// returns scores keyed by kvblock.PodEntry (a struct), which encoding/json
+// cannot use as a map key, so we flatten to a slice for the HTTP response.
+type podScoreJSON struct {
+	Pod              string  `json:"pod"`
+	DataParallelRank *int32  `json:"dataParallelRank,omitempty"`
+	Score            float64 `json:"score"`
+}
+
+// podScoresToJSON converts the indexer's (pod, dp-rank)-keyed score map into a
+// JSON-encodable slice.
+func podScoresToJSON(scores map[kvblock.PodEntry]float64) []podScoreJSON {
+	out := make([]podScoreJSON, 0, len(scores))
+	for entry, score := range scores {
+		out = append(out, podScoreJSON{
+			Pod:              entry.PodIdentifier,
+			DataParallelRank: entry.DataParallelRankPtr(),
+			Score:            score,
+		})
+	}
+	return out
+}
+
 func setupUnifiedHTTPEndpoints(
 	ctx context.Context,
 	kvCacheIndexer *kvcache.Indexer,
@@ -266,7 +289,7 @@ func setupUnifiedHTTPEndpoints(
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(pods); err != nil {
+		if err := json.NewEncoder(w).Encode(podScoresToJSON(pods)); err != nil {
 			logger.Error(err, "failed to encode response")
 		}
 	})
@@ -290,7 +313,7 @@ func setupUnifiedHTTPEndpoints(
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(pods); err != nil {
+		if err := json.NewEncoder(w).Encode(podScoresToJSON(pods)); err != nil {
 			logger.Error(err, "Failed to encode score response")
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return

--- a/examples/valkey_example/main.go
+++ b/examples/valkey_example/main.go
@@ -128,8 +128,8 @@ func demonstrateValkeyOperations(ctx context.Context, indexer *kvcache.Indexer) 
 	prompt := testdata.Prompt
 
 	podEntries := []kvblock.PodEntry{
-		{PodIdentifier: "demo-pod-1", DeviceTier: "gpu"},
-		{PodIdentifier: "demo-pod-2", DeviceTier: "gpu"},
+		{PodIdentifier: "demo-pod-1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+		{PodIdentifier: "demo-pod-2", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 	}
 
 	logger.Info("Processing testdata prompt", "model", modelName, "promptLength", len(prompt))

--- a/pkg/kvcache/dp_integration_test.go
+++ b/pkg/kvcache/dp_integration_test.go
@@ -1,0 +1,227 @@
+//go:build integration
+
+/*
+Integration test for DP-aware KV cache scoring pipeline.
+
+Tests the full flow:
+  vLLM (DP=2) -> ZMQ events -> VLLMAdapter.ParseMessage -> PodEntry with DataParallelRank
+  -> podScoringKey produces @dpN keys -> stripDPRankFromScores collapses to pod-level
+
+Run with:
+  go test -tags=integration -v -run TestDP ./pkg/kvcache/
+*/
+
+package kvcache
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents/engineadapter"
+)
+
+// TestDPScoringKeyPipeline tests the full pipeline from PodEntry through scoring to
+// scheduler-side score collapsing for Internal LB mode.
+func TestDPScoringKeyPipeline(t *testing.T) {
+	// 1. Create PodEntries as the kv-cache indexer would after receiving DP-annotated events
+	podEntries := []kvblock.PodEntry{
+		{PodIdentifier: "10.0.0.1:8000", DeviceTier: "gpu", DataParallelRank: 0},
+		{PodIdentifier: "10.0.0.1:8000", DeviceTier: "gpu", DataParallelRank: 1},
+		{PodIdentifier: "10.0.0.2:8000", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+	}
+
+	// 2. Verify String() serialization format
+	assert.Equal(t, "10.0.0.1:8000@gpu@dp0", podEntries[0].String())
+	assert.Equal(t, "10.0.0.1:8000@gpu@dp1", podEntries[1].String())
+	assert.Equal(t, "10.0.0.2:8000@gpu", podEntries[2].String())
+
+	// 3. Verify ParsePodEntry roundtrip
+	for _, entry := range podEntries {
+		parsed, err := kvblock.ParsePodEntry(entry.String())
+		require.NoError(t, err)
+		assert.Equal(t, entry.PodIdentifier, parsed.PodIdentifier)
+		assert.Equal(t, entry.DeviceTier, parsed.DeviceTier)
+		assert.Equal(t, entry.DataParallelRank, parsed.DataParallelRank)
+	}
+
+	// 4. Verify podScoringKey produces correct keys (package-private, called directly)
+	assert.Equal(t, "10.0.0.1:8000@dp0", podScoringKey(podEntries[0]))
+	assert.Equal(t, "10.0.0.1:8000@dp1", podScoringKey(podEntries[1]))
+	assert.Equal(t, "10.0.0.2:8000", podScoringKey(podEntries[2]))
+
+	// 5. Simulate raw scores as the scorer would produce
+	rawScores := map[string]float64{
+		"10.0.0.1:8000@dp0": 3.0, // rank 0 has best cache match
+		"10.0.0.1:8000@dp1": 2.0, // rank 1 has some cache match
+		"10.0.0.2:8000":     1.5, // non-DP pod (External LB mode)
+	}
+
+	// 6. Apply scheduler-side stripDPRankFromScores
+	stripped := testStripDPRankFromScores(rawScores)
+	t.Logf("Raw scores:     %v", rawScores)
+	t.Logf("Stripped scores: %v", stripped)
+
+	// Internal LB: both rank scores collapse to pod-level, highest score wins
+	assert.Equal(t, 3.0, stripped["10.0.0.1:8000"],
+		"Should keep highest score (rank 0's 3.0) for Internal LB pod")
+	// Non-DP pod passes through unchanged
+	assert.Equal(t, 1.5, stripped["10.0.0.2:8000"],
+		"Non-DP pod score should pass through unchanged")
+	// Should only have 2 entries (collapsed from 3)
+	assert.Len(t, stripped, 2, "Should collapse 3 entries to 2")
+	// No @dp keys remain
+	for key := range stripped {
+		assert.NotContains(t, key, "@dp", "Stripped scores should not contain @dp suffix")
+	}
+}
+
+// TestDPMsgpackEventParsing tests that the VLLMAdapter correctly parses
+// EventBatch payloads with data_parallel_rank from vLLM DP engines.
+func TestDPMsgpackEventParsing(t *testing.T) {
+	adapter := engineadapter.NewVLLMAdapter()
+
+	// Build a BlockStored event in vLLM msgpack array format:
+	// [tag, block_hashes, parent_hash, token_ids, block_size, lora_id, medium, lora_name, extra_keys]
+	blockStoredEvent := []any{
+		"BlockStored",
+		[]any{uint64(12345678)},
+		nil,
+		[]any{1, 2, 3, 4},
+		16,
+		nil,     // lora_id
+		"GPU",   // medium
+		nil,     // lora_name
+		[]any{}, // extra_keys
+	}
+
+	for _, tc := range []struct {
+		name     string
+		dpRank   *int
+		wantRank *int
+	}{
+		{"dp_rank=0", intPtr(0), intPtr(0)},
+		{"dp_rank=1", intPtr(1), intPtr(1)},
+		{"dp_rank=7 (higher rank)", intPtr(7), intPtr(7)},
+		// vLLM 0.16.0 always sends a 3-element array; nil dp_rank means non-DP.
+		{"dp_rank=nil (non-DP)", nil, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var dpField any
+			if tc.dpRank != nil {
+				dpField = *tc.dpRank
+			}
+			batch := []any{1234567890.0, []any{blockStoredEvent}, dpField}
+
+			payload, err := msgpack.Marshal(batch)
+			require.NoError(t, err)
+
+			msg := &kvevents.RawMessage{
+				Topic:   "kv@10.0.0.1:8000@TestModel",
+				Payload: payload,
+			}
+
+			podID, modelName, eventBatch, dpRank, err := adapter.ParseMessage(msg)
+			require.NoError(t, err)
+			assert.Equal(t, "10.0.0.1:8000", podID)
+			assert.Equal(t, "TestModel", modelName)
+			assert.Len(t, eventBatch.Events, 1)
+
+			if tc.wantRank != nil {
+				require.NotNil(t, dpRank, "Expected dp_rank=%d but got nil", *tc.wantRank)
+				assert.Equal(t, *tc.wantRank, *dpRank)
+			} else {
+				assert.Nil(t, dpRank, "Expected nil dp_rank for non-DP events")
+			}
+		})
+	}
+}
+
+// TestDPHybridLBScoring simulates Hybrid LB mode where multiple nodes each have
+// local DP ranks. Scores should collapse per-node.
+func TestDPHybridLBScoring(t *testing.T) {
+	// Node 1: ranks 0,1 — Node 2: ranks 2,3
+	rawScores := map[string]float64{
+		"node1:8000@dp0": 4.0,
+		"node1:8000@dp1": 2.5,
+		"node2:8000@dp2": 3.0,
+		"node2:8000@dp3": 1.0,
+	}
+
+	stripped := testStripDPRankFromScores(rawScores)
+
+	assert.Len(t, stripped, 2)
+	assert.Equal(t, 4.0, stripped["node1:8000"], "Node 1 should keep rank 0's score (highest)")
+	assert.Equal(t, 3.0, stripped["node2:8000"], "Node 2 should keep rank 2's score (highest)")
+}
+
+// TestDPExternalLBScoring simulates External LB mode where each rank is a separate pod.
+// No @dp suffix exists — stripDPRankFromScores is a no-op.
+func TestDPExternalLBScoring(t *testing.T) {
+	rawScores := map[string]float64{
+		"10.0.0.1:8000": 3.0, // rank 0 pod
+		"10.0.0.2:8000": 2.0, // rank 1 pod
+		"10.0.0.3:8000": 1.5, // rank 2 pod
+	}
+
+	stripped := testStripDPRankFromScores(rawScores)
+
+	// Should be identical — no @dp suffixes to strip
+	assert.Equal(t, rawScores, stripped, "External LB scores should pass through unchanged")
+}
+
+// TestDPMixedModes simulates a mixed environment with both DP and non-DP pods.
+func TestDPMixedModes(t *testing.T) {
+	rawScores := map[string]float64{
+		"dp-pod:8000@dp0":     5.0, // Internal LB pod, rank 0
+		"dp-pod:8000@dp1":     3.0, // Internal LB pod, rank 1
+		"standalone-pod:8000": 4.0, // Non-DP pod
+	}
+
+	stripped := testStripDPRankFromScores(rawScores)
+
+	assert.Len(t, stripped, 2)
+	assert.Equal(t, 5.0, stripped["dp-pod:8000"])
+	assert.Equal(t, 4.0, stripped["standalone-pod:8000"])
+}
+
+// --- Helper functions replicating scheduler logic ---
+
+// testStripDPRankFromScores replicates scheduler's pkg/plugins/scorer/utils.go:stripDPRankFromScores
+func testStripDPRankFromScores(scores map[string]float64) map[string]float64 {
+	stripped := make(map[string]float64, len(scores))
+	for key, score := range scores {
+		baseKey := testStripDPRankSuffix(key)
+		if existing, ok := stripped[baseKey]; !ok || score > existing {
+			stripped[baseKey] = score
+		}
+	}
+	return stripped
+}
+
+// testStripDPRankSuffix replicates scheduler's pkg/common/dp.go:StripDPRankSuffix
+func testStripDPRankSuffix(key string) string {
+	idx := strings.LastIndex(key, "@dp")
+	if idx < 0 {
+		return key
+	}
+	suffix := key[idx+3:]
+	for _, c := range suffix {
+		if c < '0' || c > '9' {
+			return key
+		}
+	}
+	if len(suffix) == 0 {
+		return key
+	}
+	return key[:idx]
+}
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/pkg/kvcache/dp_integration_test.go
+++ b/pkg/kvcache/dp_integration_test.go
@@ -5,7 +5,8 @@ Integration test for DP-aware KV cache scoring pipeline.
 
 Tests the full flow:
   vLLM (DP=2) -> ZMQ events -> VLLMAdapter.ParseMessage -> PodEntry with DataParallelRank
-  -> podScoringKey produces @dpN keys -> stripDPRankFromScores collapses to pod-level
+  -> scoringKey produces (pod, rank) keys -> gRPC sends (pod, data_parallel_rank)
+  -> scheduler-side stripDPRankFromScores collapses to pod-level
 
 Run with:
   go test -tags=integration -v -run TestDP ./pkg/kvcache/
@@ -50,12 +51,15 @@ func TestDPScoringKeyPipeline(t *testing.T) {
 		assert.Equal(t, entry.DataParallelRank, parsed.DataParallelRank)
 	}
 
-	// 4. Verify podScoringKey produces correct keys (package-private, called directly)
-	assert.Equal(t, "10.0.0.1:8000@dp0", podScoringKey(podEntries[0]))
-	assert.Equal(t, "10.0.0.1:8000@dp1", podScoringKey(podEntries[1]))
-	assert.Equal(t, "10.0.0.2:8000", podScoringKey(podEntries[2]))
+	// 4. Verify scoringKey produces correct (pod, rank) keys, dropping the
+	//    device tier (package-private, called directly). The scorer keys its
+	//    result map by these PodEntry values rather than by encoded strings.
+	assert.Equal(t, kvblock.PodEntry{PodIdentifier: "10.0.0.1:8000", DataParallelRank: 0}, scoringKey(podEntries[0]))
+	assert.Equal(t, kvblock.PodEntry{PodIdentifier: "10.0.0.1:8000", DataParallelRank: 1}, scoringKey(podEntries[1]))
+	assert.Equal(t, kvblock.PodEntry{PodIdentifier: "10.0.0.2:8000", DataParallelRank: kvblock.NoDataParallelRank}, scoringKey(podEntries[2]))
 
-	// 5. Simulate raw scores as the scorer would produce
+	// 5. Simulate the scheduler-side keys built from gRPC (pod, data_parallel_rank)
+	//    fields. The scheduler reconstructs "pod@dpN" strings for collapsing.
 	rawScores := map[string]float64{
 		"10.0.0.1:8000@dp0": 3.0, // rank 0 has best cache match
 		"10.0.0.1:8000@dp1": 2.0, // rank 1 has some cache match

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -202,7 +202,7 @@ func (k *Indexer) ComputeBlockKeysFromTokens(ctx context.Context, tokens []uint3
 // Deprecated: use ScoreTokens.
 func (k *Indexer) GetPodScores(ctx context.Context, renderReq *types.RenderChatRequest, prompt, modelName string,
 	podIdentifiers []string,
-) (map[string]float64, error) {
+) (map[kvblock.PodEntry]float64, error) {
 	if k.tokenizersPool == nil {
 		return nil, ErrInternalTokenizationDisabled
 	}
@@ -242,7 +242,7 @@ func (k *Indexer) ScoreTokens(
 	modelName string,
 	podIdentifiers []string,
 	extraFeatures []*kvblock.BlockExtraFeatures,
-) (map[string]float64, error) {
+) (map[kvblock.PodEntry]float64, error) {
 	tracer := otel.Tracer(telemetry.InstrumentationName)
 	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.score_tokens",
 		trace.WithSpanKind(trace.SpanKindInternal),

--- a/pkg/kvcache/indexer_test.go
+++ b/pkg/kvcache/indexer_test.go
@@ -136,9 +136,9 @@ var scoringTests = []scoringTestCase{
 		blockKeys: []uint64{10, 20, 30},
 		tokens:    []uint32{1, 2, 3},
 		indexEntries: map[kvblock.BlockHash][]kvblock.PodEntry{
-			10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-			20: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-			30: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+			10: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+			20: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+			30: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 		},
 		wantScores: map[string]float64{testPodA: 3.0},
 	},
@@ -148,15 +148,15 @@ var scoringTests = []scoringTestCase{
 		tokens:    []uint32{1, 2, 3},
 		indexEntries: map[kvblock.BlockHash][]kvblock.PodEntry{
 			10: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
-				{PodIdentifier: testPodB, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+				{PodIdentifier: testPodB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 			},
 			20: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
-				{PodIdentifier: testPodB, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+				{PodIdentifier: testPodB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 			},
 			30: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 			},
 		},
 		wantScores: map[string]float64{testPodA: 3.0, testPodB: 2.0},
@@ -166,8 +166,8 @@ var scoringTests = []scoringTestCase{
 		blockKeys: []uint64{10, 20},
 		tokens:    []uint32{1, 2},
 		indexEntries: map[kvblock.BlockHash][]kvblock.PodEntry{
-			10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-			20: {{PodIdentifier: testPodA, DeviceTier: "cpu"}},
+			10: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+			20: {{PodIdentifier: testPodA, DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank}},
 		},
 		wantScores: map[string]float64{testPodA: 1.8}, // gpu(1.0) + cpu(0.8)
 	},
@@ -177,12 +177,12 @@ var scoringTests = []scoringTestCase{
 		tokens:    []uint32{1, 2},
 		indexEntries: map[kvblock.BlockHash][]kvblock.PodEntry{
 			10: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
-				{PodIdentifier: testPodB, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+				{PodIdentifier: testPodB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 			},
 			20: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
-				{PodIdentifier: testPodB, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+				{PodIdentifier: testPodB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 			},
 		},
 		podIdentifiers: []string{testPodA},
@@ -194,16 +194,16 @@ var scoringTests = []scoringTestCase{
 		tokens:    []uint32{1, 2, 3},
 		indexEntries: map[kvblock.BlockHash][]kvblock.PodEntry{
 			10: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
-				{PodIdentifier: testPodB, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+				{PodIdentifier: testPodB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 			},
 			20: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 				// testPodB missing => prefix breaks for podB
 			},
 			30: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
-				{PodIdentifier: testPodB, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+				{PodIdentifier: testPodB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 			},
 		},
 		wantScores: map[string]float64{testPodA: 3.0, testPodB: 1.0},
@@ -214,8 +214,8 @@ var scoringTests = []scoringTestCase{
 		tokens:    []uint32{1},
 		indexEntries: map[kvblock.BlockHash][]kvblock.PodEntry{
 			10: {
-				{PodIdentifier: testPodA, DeviceTier: "gpu"},
-				{PodIdentifier: testPodB, DeviceTier: "gpu"},
+				{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+				{PodIdentifier: testPodB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 			},
 		},
 		podIdentifiers: []string{},
@@ -226,8 +226,8 @@ var scoringTests = []scoringTestCase{
 		blockKeys: []uint64{10, 20},
 		tokens:    []uint32{42, 43},
 		indexEntries: map[kvblock.BlockHash][]kvblock.PodEntry{
-			10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-			20: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+			10: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+			20: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 		},
 		wantScores: map[string]float64{testPodA: 2.0},
 	},
@@ -300,9 +300,9 @@ func TestGetPodScores_TruncatePromptTokens(t *testing.T) {
 
 	ctx := logging.NewTestLoggerIntoContext(context.Background())
 	populateIndex(t, indexer.KVBlockIndex(), map[kvblock.BlockHash][]kvblock.PodEntry{
-		10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-		20: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-		30: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+		10: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		20: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		30: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 	})
 
 	truncateLimit := 3
@@ -328,8 +328,8 @@ func TestGetPodScores_TruncateNoOp(t *testing.T) {
 
 	ctx := logging.NewTestLoggerIntoContext(context.Background())
 	populateIndex(t, indexer.KVBlockIndex(), map[kvblock.BlockHash][]kvblock.PodEntry{
-		10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-		20: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+		10: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		20: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 	})
 
 	truncateLimit := 100 // larger than token count
@@ -354,8 +354,8 @@ func TestGetPodScores_TruncateZero(t *testing.T) {
 
 	ctx := logging.NewTestLoggerIntoContext(context.Background())
 	populateIndex(t, indexer.KVBlockIndex(), map[kvblock.BlockHash][]kvblock.PodEntry{
-		10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-		20: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+		10: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		20: {{PodIdentifier: testPodA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 	})
 
 	truncateLimit := 0

--- a/pkg/kvcache/indexer_test.go
+++ b/pkg/kvcache/indexer_test.go
@@ -233,8 +233,20 @@ var scoringTests = []scoringTestCase{
 	},
 }
 
-// assertScores verifies that the returned scores match expectations.
-func assertScores(t *testing.T, tt *scoringTestCase, scores map[string]float64, err error) {
+// nonDPScoreKey builds the score-map key the scorer produces for a non-DP pod.
+func nonDPScoreKey(pod string) kvblock.PodEntry {
+	return kvblock.PodEntry{PodIdentifier: pod, DataParallelRank: kvblock.NoDataParallelRank}
+}
+
+// dpScoreKey builds the score-map key the scorer produces for a DP-aware pod.
+func dpScoreKey(pod string, rank int) kvblock.PodEntry {
+	return kvblock.PodEntry{PodIdentifier: pod, DataParallelRank: rank}
+}
+
+// assertScores verifies that the returned scores match expectations. The
+// scorer keys results by kvblock.PodEntry; these scenarios are all non-DP, so
+// the expected key is the pod identifier with NoDataParallelRank.
+func assertScores(t *testing.T, tt *scoringTestCase, scores map[kvblock.PodEntry]float64, err error) {
 	t.Helper()
 	require.NoError(t, err)
 
@@ -245,8 +257,9 @@ func assertScores(t *testing.T, tt *scoringTestCase, scores map[string]float64, 
 
 	require.Len(t, scores, len(tt.wantScores), "unexpected number of scored pods")
 	for pod, want := range tt.wantScores {
-		require.Contains(t, scores, pod, "missing pod %q in scores", pod)
-		assert.InDelta(t, want, scores[pod], 0.0001, "pod %q score mismatch", pod)
+		key := kvblock.PodEntry{PodIdentifier: pod, DataParallelRank: kvblock.NoDataParallelRank}
+		require.Contains(t, scores, key, "missing pod %q in scores", pod)
+		assert.InDelta(t, want, scores[key], 0.0001, "pod %q score mismatch", pod)
 	}
 }
 
@@ -312,8 +325,8 @@ func TestGetPodScores_TruncatePromptTokens(t *testing.T) {
 
 	scores, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
 	require.NoError(t, err)
-	require.Contains(t, scores, testPodA)
-	assert.InDelta(t, 3.0, scores[testPodA], 0.0001)
+	require.Contains(t, scores, nonDPScoreKey(testPodA))
+	assert.InDelta(t, 3.0, scores[nonDPScoreKey(testPodA)], 0.0001)
 	assert.Equal(t, []uint32{300, 400, 500}, tp.receivedTokens,
 		"token processor should receive only the last 3 tokens after truncation")
 }
@@ -339,8 +352,8 @@ func TestGetPodScores_TruncateNoOp(t *testing.T) {
 
 	scores, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
 	require.NoError(t, err)
-	require.Contains(t, scores, testPodA)
-	assert.InDelta(t, 2.0, scores[testPodA], 0.0001)
+	require.Contains(t, scores, nonDPScoreKey(testPodA))
+	assert.InDelta(t, 2.0, scores[nonDPScoreKey(testPodA)], 0.0001)
 	assert.Equal(t, []uint32{1, 2}, tp.receivedTokens,
 		"token processor should receive all tokens when limit exceeds count")
 }
@@ -365,8 +378,8 @@ func TestGetPodScores_TruncateZero(t *testing.T) {
 
 	scores, err := indexer.GetPodScores(ctx, renderReq, "", testModel, nil)
 	require.NoError(t, err)
-	require.Contains(t, scores, testPodA)
-	assert.InDelta(t, 2.0, scores[testPodA], 0.0001, "zero limit should not truncate")
+	require.Contains(t, scores, nonDPScoreKey(testPodA))
+	assert.InDelta(t, 2.0, scores[nonDPScoreKey(testPodA)], 0.0001, "zero limit should not truncate")
 	assert.Equal(t, []uint32{1, 2}, tp.receivedTokens,
 		"token processor should receive all tokens when limit is zero")
 }

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -151,6 +151,7 @@ func (c *CostPodCache) CalculateByteSize(keyStr string) int64 {
 		totalBytes += int64(len(entry.PodIdentifier)) // PodIdentifier string content
 		totalBytes += int64(len(entry.DeviceTier))    // DeviceTier string content
 		totalBytes += 32                              // string headers (16 bytes each for 2 strings)
+		totalBytes += 8                               // DataParallelRank int field (8 bytes on 64-bit)
 		totalBytes += 8                               // struct padding/alignment
 		return true
 	})

--- a/pkg/kvcache/kvblock/cost_aware_memory_test.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory_test.go
@@ -47,7 +47,7 @@ func TestCostAwareIndexSize(t *testing.T) {
 	// first key
 	engineKey1 := BlockHash(32490241)
 	requestKey1 := BlockHash(18986637)
-	entry1 := PodEntry{PodIdentifier: "pod1", DeviceTier: "gpu"}
+	entry1 := PodEntry{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 
 	costPodCache := &CostPodCache{}
 	costPodCache.Add(entry1)
@@ -66,13 +66,13 @@ func TestCostAwareIndexSize(t *testing.T) {
 	// Add second key
 	engineKey2 := BlockHash(48712468)
 	requestKey2 := BlockHash(87654321)
-	err = index.Add(ctx, []BlockHash{engineKey2}, []BlockHash{requestKey2}, []PodEntry{{PodIdentifier: "pod2", DeviceTier: "gpu"}})
+	err = index.Add(ctx, []BlockHash{engineKey2}, []BlockHash{requestKey2}, []PodEntry{{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}})
 	require.NoError(t, err)
 
 	// Add third key - should evict the first one due to LRU
 	engineKey3 := BlockHash(96187092)
 	requestKey3 := BlockHash(56789012)
-	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
+	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank}})
 	require.NoError(t, err)
 
 	// Lookup should only return the last two keys
@@ -82,7 +82,7 @@ func TestCostAwareIndexSize(t *testing.T) {
 	assert.Len(t, podsPerKey, 1) // Only requestKey3 should be present
 	assert.Len(t, podsPerKey[requestKey3], 1)
 
-	assert.Contains(t, podsPerKey[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
+	assert.Contains(t, podsPerKey[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank})
 }
 
 func TestSizeHumanize(t *testing.T) {

--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -57,19 +57,19 @@ func TestInMemoryIndexSize(t *testing.T) {
 	// Add first key
 	engineKey1 := BlockHash(72735753)
 	requestKey1 := BlockHash(79215516)
-	err = index.Add(ctx, []BlockHash{engineKey1}, []BlockHash{requestKey1}, []PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}})
+	err = index.Add(ctx, []BlockHash{engineKey1}, []BlockHash{requestKey1}, []PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}})
 	require.NoError(t, err)
 
 	// Add second key
 	engineKey2 := BlockHash(41341092)
 	requestKey2 := BlockHash(12871930)
-	err = index.Add(ctx, []BlockHash{engineKey2}, []BlockHash{requestKey2}, []PodEntry{{PodIdentifier: "pod2", DeviceTier: "gpu"}})
+	err = index.Add(ctx, []BlockHash{engineKey2}, []BlockHash{requestKey2}, []PodEntry{{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}})
 	require.NoError(t, err)
 
 	// Add third key - should evict the first one due to LRU
 	engineKey3 := BlockHash(34012886)
 	requestKey3 := BlockHash(69914638)
-	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
+	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank}})
 	require.NoError(t, err)
 
 	// Lookup should only return the last two keys
@@ -79,8 +79,8 @@ func TestInMemoryIndexSize(t *testing.T) {
 	assert.Len(t, podsPerKey, 2) // Only key2 and key3 should be present
 	assert.Len(t, podsPerKey[requestKey2], 1)
 	assert.Len(t, podsPerKey[requestKey3], 1)
-	assert.Contains(t, podsPerKey[requestKey2], PodEntry{PodIdentifier: "pod2", DeviceTier: "gpu"})
-	assert.Contains(t, podsPerKey[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
+	assert.Contains(t, podsPerKey[requestKey2], PodEntry{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank})
+	assert.Contains(t, podsPerKey[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank})
 }
 
 func TestInMemoryIndexPodCacheSize(t *testing.T) {
@@ -99,9 +99,9 @@ func TestInMemoryIndexPodCacheSize(t *testing.T) {
 	engineKey := BlockHash(28409753)
 	requestKey := BlockHash(51374550)
 	pods := []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "gpu"},
-		{PodIdentifier: "pod3", DeviceTier: "cpu"}, // This should evict pod1 due to LRU
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod3", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank}, // This should evict pod1 due to LRU
 	}
 
 	err = index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, pods)
@@ -112,8 +112,8 @@ func TestInMemoryIndexPodCacheSize(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, podsPerKey, 1)
 	assert.Len(t, podsPerKey[requestKey], 2, "Should only have 2 pods due to PodCacheSize limit")
-	assert.Contains(t, podsPerKey[requestKey], PodEntry{PodIdentifier: "pod2", DeviceTier: "gpu"})
-	assert.Contains(t, podsPerKey[requestKey], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
+	assert.Contains(t, podsPerKey[requestKey], PodEntry{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank})
+	assert.Contains(t, podsPerKey[requestKey], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank})
 }
 
 // TestSpeculativeAnnotation tests that speculative and confirmed PodEntries
@@ -127,7 +127,7 @@ func TestSpeculativeAnnotation(t *testing.T) {
 
 	t.Run("SpeculativeAddWithNilEngineKeys", func(t *testing.T) {
 		// Add a speculative entry with nil engineKeys (no engineKey mapping)
-		speculativePod := PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true}
+		speculativePod := PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true, DataParallelRank: NoDataParallelRank}
 		err := index.Add(ctx, nil, []BlockHash{requestKey}, []PodEntry{speculativePod})
 		require.NoError(t, err)
 
@@ -141,7 +141,7 @@ func TestSpeculativeAnnotation(t *testing.T) {
 	t.Run("SpeculativeAndConfirmedCoexist", func(t *testing.T) {
 		// Add a confirmed entry for the same pod (with engineKey mapping, same requestKey)
 		confirmedEngineKey := BlockHash(33333333)
-		confirmedPod := PodEntry{PodIdentifier: "10.0.0.1:8080"}
+		confirmedPod := PodEntry{PodIdentifier: "10.0.0.1:8080", DataParallelRank: NoDataParallelRank}
 		err := index.Add(ctx, []BlockHash{confirmedEngineKey}, []BlockHash{requestKey}, []PodEntry{confirmedPod})
 		require.NoError(t, err)
 
@@ -150,13 +150,13 @@ func TestSpeculativeAnnotation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, podsPerKey[requestKey], 2)
 		assert.Contains(t, podsPerKey[requestKey],
-			PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true})
-		assert.Contains(t, podsPerKey[requestKey], PodEntry{PodIdentifier: "10.0.0.1:8080"})
+			PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true, DataParallelRank: NoDataParallelRank})
+		assert.Contains(t, podsPerKey[requestKey], PodEntry{PodIdentifier: "10.0.0.1:8080", DataParallelRank: NoDataParallelRank})
 	})
 
 	t.Run("SpeculativeEvictPreservesConfirmed", func(t *testing.T) {
 		// Evict the speculative entry using requestKey directly (no engineKey mapping exists).
-		speculativePod := PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true}
+		speculativePod := PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true, DataParallelRank: NoDataParallelRank}
 		err := index.Evict(ctx, requestKey, RequestKey, []PodEntry{speculativePod})
 		require.NoError(t, err)
 
@@ -164,10 +164,10 @@ func TestSpeculativeAnnotation(t *testing.T) {
 		podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
 		require.NoError(t, err)
 		assert.Len(t, podsPerKey[requestKey], 1)
-		assert.Contains(t, podsPerKey[requestKey], PodEntry{PodIdentifier: "10.0.0.1:8080"})
+		assert.Contains(t, podsPerKey[requestKey], PodEntry{PodIdentifier: "10.0.0.1:8080", DataParallelRank: NoDataParallelRank})
 		// Speculative should be gone
 		assert.NotContains(t, podsPerKey[requestKey],
-			PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true})
+			PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true, DataParallelRank: NoDataParallelRank})
 	})
 }
 
@@ -178,7 +178,7 @@ func TestSpeculativeEvictThenEmpty(t *testing.T) {
 	index := createInMemoryIndexForTesting(t)
 
 	requestKey := BlockHash(44444444)
-	speculativePod := PodEntry{PodIdentifier: "10.0.0.2:8080", Speculative: true}
+	speculativePod := PodEntry{PodIdentifier: "10.0.0.2:8080", Speculative: true, DataParallelRank: NoDataParallelRank}
 
 	// Add speculative entry with nil engineKeys (no engineKey mapping)
 	err := index.Add(ctx, nil, []BlockHash{requestKey}, []PodEntry{speculativePod})
@@ -206,7 +206,7 @@ func TestAddWithNilEngineKeys(t *testing.T) {
 	index := createInMemoryIndexForTesting(t)
 
 	requestKey := BlockHash(55555555)
-	pod := PodEntry{PodIdentifier: "10.0.0.3:8080", Speculative: true}
+	pod := PodEntry{PodIdentifier: "10.0.0.3:8080", Speculative: true, DataParallelRank: NoDataParallelRank}
 
 	// Add with nil engineKeys
 	err := index.Add(ctx, nil, []BlockHash{requestKey}, []PodEntry{pod})
@@ -221,4 +221,73 @@ func TestAddWithNilEngineKeys(t *testing.T) {
 	// GetRequestKey should NOT find a mapping (no engineKey was stored)
 	_, err = index.GetRequestKey(ctx, requestKey)
 	assert.Error(t, err, "GetRequestKey should fail since no engineKey mapping was created")
+}
+
+// TestPodEntryString tests the String() method with and without Annotation.
+func TestPodEntryString(t *testing.T) {
+	confirmed := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
+	assert.Equal(t, "10.0.0.1:8080@gpu", confirmed.String())
+
+	speculative := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", Speculative: true, DataParallelRank: NoDataParallelRank}
+	assert.Equal(t, "10.0.0.1:8080@gpu[speculative]", speculative.String())
+
+	notSpeculative := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", Speculative: false, DataParallelRank: NoDataParallelRank}
+	assert.Equal(t, "10.0.0.1:8080@gpu", notSpeculative.String())
+
+	// DP rank without speculative
+	dpEntry := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", DataParallelRank: 0}
+	assert.Equal(t, "10.0.0.1:8080@gpu@dp0", dpEntry.String())
+
+	dpEntry2 := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", DataParallelRank: 3}
+	assert.Equal(t, "10.0.0.1:8080@gpu@dp3", dpEntry2.String())
+
+	// DP rank WITH speculative — the critical edge case
+	speculativeDP := PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu", Speculative: true, DataParallelRank: 1}
+	assert.Equal(t, "10.0.0.1:8080@gpu@dp1[speculative]", speculativeDP.String())
+
+	// Roundtrip: String() -> ParsePodEntry for all combinations
+	for _, entry := range []PodEntry{confirmed, speculative, notSpeculative, dpEntry, dpEntry2, speculativeDP} {
+		parsed, err := ParsePodEntry(entry.String())
+		assert.NoError(t, err, "ParsePodEntry(%q) failed", entry.String())
+		assert.Equal(t, entry.PodIdentifier, parsed.PodIdentifier, "PodIdentifier mismatch for %q", entry.String())
+		assert.Equal(t, entry.DeviceTier, parsed.DeviceTier, "DeviceTier mismatch for %q", entry.String())
+		assert.Equal(t, entry.DataParallelRank, parsed.DataParallelRank, "DataParallelRank mismatch for %q", entry.String())
+		assert.Equal(t, entry.Speculative, parsed.Speculative, "Speculative mismatch for %q", entry.String())
+	}
+}
+
+// TestParsePodEntryMalformedDP ensures ParsePodEntry rejects malformed DP
+// suffixes rather than silently treating them as device tiers. Previously a
+// string like "pod@tier@dpXYZ" was split into 2 parts and accepted as
+// {Pod:"pod@tier", Tier:"dpXYZ"}; now it must surface an error.
+func TestParsePodEntryMalformedDP(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr string // substring expected in the error message
+	}{
+		{"pod@gpu@dpXYZ", "invalid dp rank number"},      // non-digit suffix
+		{"pod@gpu@dp", "invalid dp rank format"},         // empty digits
+		{"pod@gpu@dp-1", "dp rank must be non-negative"}, // negative rank
+		{"pod@gpu@dp-42", "dp rank must be non-negative"},
+		{"pod@gpu@dp1.5", "invalid dp rank number"}, // not an integer
+		{"10.0.0.1:8080@gpu@dpBAD[speculative]", "invalid dp rank number"},
+	}
+	for _, tc := range cases {
+		_, err := ParsePodEntry(tc.in)
+		assert.Error(t, err, "ParsePodEntry(%q) should have errored", tc.in)
+		if err != nil {
+			assert.Contains(t, err.Error(), tc.wantErr, "unexpected error for %q", tc.in)
+		}
+	}
+
+	// Well-formed DP entries must still parse cleanly.
+	okCases := []string{
+		"pod@gpu@dp0",
+		"pod@gpu@dp42",
+		"10.0.0.1:8080@gpu@dp3[speculative]",
+	}
+	for _, s := range okCases {
+		_, err := ParsePodEntry(s)
+		assert.NoError(t, err, "ParsePodEntry(%q) should have succeeded", s)
+	}
 }

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -20,10 +20,18 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
-	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/metrics"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/metrics"
+)
+
+const (
+	// NoDataParallelRank indicates that no data parallel rank is set.
+	// This is the default value for non-DP deployments.
+	NoDataParallelRank = -1
 )
 
 // IndexConfig holds the configuration for the KV-block index.
@@ -184,9 +192,31 @@ type PodEntry struct {
 	HasGroup bool
 	// GroupIdx identifies the vLLM KV cache group for HMA events.
 	GroupIdx GroupID
+	// DataParallelRank is the data parallel rank of the pod.
+	// A value of NoDataParallelRank (-1) indicates no DP rank is set (non-DP deployment).
+	DataParallelRank int
+}
+
+// NewPodEntry creates a PodEntry, converting a *int DP rank to the int sentinel form.
+// A nil dpRank is stored as NoDataParallelRank (-1). A negative dpRank is also
+// treated as NoDataParallelRank: valid DP ranks are non-negative, and storing
+// a negative value would break roundtripping through ParsePodEntry (which
+// rejects them) and cause the pod to drop out of lookups.
+func NewPodEntry(podIdentifier, deviceTier string, dpRank *int) PodEntry {
+	rank := NoDataParallelRank
+	if dpRank != nil && *dpRank >= 0 {
+		rank = *dpRank
+	}
+	return PodEntry{
+		PodIdentifier:    podIdentifier,
+		DeviceTier:       deviceTier,
+		DataParallelRank: rank,
+	}
 }
 
 // String returns a string representation of the PodEntry.
+// Format: "pod@tier" (no DP rank) or "pod@tier@dpN" (with DP rank).
+// The [speculative] annotation, if present, is always appended last.
 func (e *PodEntry) String() string {
 	suffix := ""
 	if e.Speculative {
@@ -195,5 +225,76 @@ func (e *PodEntry) String() string {
 	if e.HasGroup {
 		suffix += fmt.Sprintf("[group=%d]", e.GroupIdx)
 	}
-	return fmt.Sprintf("%s@%s%s", e.PodIdentifier, e.DeviceTier, suffix)
+
+	if e.DataParallelRank == NoDataParallelRank {
+		return fmt.Sprintf("%s@%s%s", e.PodIdentifier, e.DeviceTier, suffix)
+	}
+	return fmt.Sprintf("%s@%s@dp%d%s", e.PodIdentifier, e.DeviceTier, e.DataParallelRank, suffix)
+}
+
+// ParsePodEntry parses a PodEntry from its string representation.
+// It handles "pod@tier", "pod@tier@dpN", and variants with "[speculative]" suffix.
+func ParsePodEntry(s string) (PodEntry, error) {
+	// Strip [speculative] suffix if present (always appended at the end by String()).
+	speculative := false
+	if strings.HasSuffix(s, "[speculative]") {
+		speculative = true
+		s = s[:len(s)-len("[speculative]")]
+	}
+
+	// Try 3-part format first: "pod@tier@dpN"
+	parts := splitPodEntryString(s)
+	switch len(parts) {
+	case 3:
+		dpStr := parts[2]
+		if len(dpStr) < 3 || dpStr[:2] != "dp" {
+			return PodEntry{}, fmt.Errorf("invalid dp rank format: %s", dpStr)
+		}
+		rank, err := strconv.Atoi(dpStr[2:])
+		if err != nil {
+			return PodEntry{}, fmt.Errorf("invalid dp rank number: %s", dpStr)
+		}
+		if rank < 0 {
+			return PodEntry{}, fmt.Errorf("dp rank must be non-negative, got %d", rank)
+		}
+		return PodEntry{
+			PodIdentifier:    parts[0],
+			DeviceTier:       parts[1],
+			DataParallelRank: rank,
+			Speculative:      speculative,
+		}, nil
+	case 2:
+		return PodEntry{
+			PodIdentifier:    parts[0],
+			DeviceTier:       parts[1],
+			DataParallelRank: NoDataParallelRank,
+			Speculative:      speculative,
+		}, nil
+	default:
+		return PodEntry{}, fmt.Errorf("invalid pod entry format: %s", s)
+	}
+}
+
+// splitPodEntryString splits a PodEntry string into its components.
+// It splits from the right to handle pod identifiers that may contain '@'.
+//
+// When the suffix after the last '@' starts with "dp" AND there is a second
+// '@' earlier (tier separator), the string is always split into 3 parts —
+// even when the dp suffix is malformed (e.g. "dpXYZ", "dp", "dp-1"). This
+// lets ParsePodEntry surface a proper validation error instead of silently
+// accepting a malformed suffix as a device tier.
+func splitPodEntryString(s string) []string {
+	lastAt := strings.LastIndexByte(s, '@')
+	if lastAt < 0 {
+		return []string{s}
+	}
+	suffix := s[lastAt+1:]
+	if strings.HasPrefix(suffix, "dp") {
+		rest := s[:lastAt]
+		if secondLastAt := strings.LastIndexByte(rest, '@'); secondLastAt >= 0 {
+			return []string{rest[:secondLastAt], rest[secondLastAt+1:], suffix}
+		}
+	}
+	// 2-part format: "pod@tier"
+	return []string{s[:lastAt], s[lastAt+1:]}
 }

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -214,6 +214,18 @@ func NewPodEntry(podIdentifier, deviceTier string, dpRank *int) PodEntry {
 	}
 }
 
+// DataParallelRankPtr returns the DP rank as an *int32 suitable for the
+// protobuf `optional int32` field: nil when the pod is non-DP
+// (DataParallelRank == NoDataParallelRank), otherwise a pointer to the rank.
+// This keeps "absent" (nil) distinct from the valid "rank 0" case.
+func (e PodEntry) DataParallelRankPtr() *int32 {
+	if e.DataParallelRank == NoDataParallelRank {
+		return nil
+	}
+	r := int32(e.DataParallelRank)
+	return &r
+}
+
 // String returns a string representation of the PodEntry.
 // Format: "pod@tier" (no DP rank) or "pod@tier@dpN" (with DP rank).
 // The [speculative] annotation, if present, is always appended last.

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -146,8 +146,8 @@ func testBasicAddAndLookup(t *testing.T, ctx context.Context, index Index) {
 	engineKey := BlockHash(55269488)
 	requestKey := BlockHash(10633516)
 	entries := []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "gpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	}
 
 	// Add entries
@@ -160,8 +160,8 @@ func testBasicAddAndLookup(t *testing.T, ctx context.Context, index Index) {
 	assert.Len(t, podsPerKey, 1)
 	assert.Contains(t, podsPerKey, requestKey)
 	assert.ElementsMatch(t, podsPerKey[requestKey], []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "gpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	})
 }
 
@@ -175,8 +175,8 @@ func testDuplicatePodHandling(t *testing.T, ctx context.Context, index Index) {
 
 	// First batch of entries
 	entries1 := []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "gpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	}
 
 	err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, entries1)
@@ -184,9 +184,9 @@ func testDuplicatePodHandling(t *testing.T, ctx context.Context, index Index) {
 
 	// Second batch with one duplicate pod but different tier
 	entries2 := []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"}, // Same pod, same tier
-		{PodIdentifier: "pod2", DeviceTier: "cpu"}, // Same pod, different tier
-		{PodIdentifier: "pod3", DeviceTier: "gpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}, // Same pod, same tier
+		{PodIdentifier: "pod2", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank}, // Same pod, different tier
+		{PodIdentifier: "pod3", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	}
 
 	err = index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, entries2)
@@ -202,10 +202,10 @@ func testDuplicatePodHandling(t *testing.T, ctx context.Context, index Index) {
 	// Should contain all pod entries, including duplicates with different tiers
 	// Expected: pod1(gpu), pod2(gpu), pod2(cpu), pod3(gpu)
 	expected := []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "cpu"},
-		{PodIdentifier: "pod3", DeviceTier: "gpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod3", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	}
 	assert.ElementsMatch(t, podsPerKey[requestKey], expected)
 }
@@ -217,9 +217,9 @@ func testFilteredLookup(t *testing.T, ctx context.Context, index Index) {
 	engineKey := BlockHash(93788608)
 	requestKey := BlockHash(55204205)
 	entries := []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "gpu"},
-		{PodIdentifier: "pod3", DeviceTier: "gpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod3", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	}
 
 	err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, entries)
@@ -231,7 +231,7 @@ func testFilteredLookup(t *testing.T, ctx context.Context, index Index) {
 	require.NoError(t, err)
 	assert.Len(t, podsPerKey, 1)
 	assert.Contains(t, podsPerKey, requestKey)
-	assert.Equal(t, []PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}}, podsPerKey[requestKey])
+	assert.Equal(t, []PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}}, podsPerKey[requestKey])
 
 	// Lookup with multiple filters
 	filterSet = sets.New("pod1", "pod3")
@@ -239,8 +239,8 @@ func testFilteredLookup(t *testing.T, ctx context.Context, index Index) {
 	require.NoError(t, err)
 	assert.Len(t, podsPerKey, 1)
 	assert.ElementsMatch(t, podsPerKey[requestKey], []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod3", DeviceTier: "gpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod3", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	})
 
 	// Lookup with non-existent pod filter should return empty result
@@ -257,33 +257,34 @@ func testEvictBasic(t *testing.T, ctx context.Context, index Index) {
 	engineKey := BlockHash(17434655)
 	requestKey := BlockHash(59244875)
 	entries := []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "gpu"},
-		{PodIdentifier: "pod3", DeviceTier: "gpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod3", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	}
 
 	// Add entries
 	err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, entries)
 	require.NoError(t, err)
 
-	// Evict specific pod entries (note: eviction is based on pod identifier only)
+	// Evict specific pod entries. Eviction matches the full PodEntry
+	// (PodIdentifier + DeviceTier + DataParallelRank), so a mismatched
+	// DeviceTier like pod3@cpu does NOT evict the stored pod3@gpu.
 	evictEntries := []PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod3", DeviceTier: "cpu"}, // Device tier may differ from stored entry
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod3", DeviceTier: "cpu", DataParallelRank: NoDataParallelRank}, // tier differs from stored entry -> no match
 	}
 
 	err = index.Evict(ctx, engineKey, EngineKey, evictEntries)
 	require.NoError(t, err)
 
-	// Verify that pod1 was evicted but pod2 and pod3 remain
-	// Note: pod3 remains because eviction only matched pod identifier, not device tier
+	// pod1@gpu was evicted (full match); pod3@gpu remains (evict used cpu tier, no match); pod2@gpu untouched.
 	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey}, sets.Set[string]{})
 	require.NoError(t, err)
 	assert.Len(t, podsPerKey, 1)
 	assert.Contains(t, podsPerKey, requestKey)
 	expected := []PodEntry{
-		{PodIdentifier: "pod2", DeviceTier: "gpu"},
-		{PodIdentifier: "pod3", DeviceTier: "gpu"},
+		{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+		{PodIdentifier: "pod3", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 	}
 	assert.ElementsMatch(t, expected, podsPerKey[requestKey])
 }
@@ -306,7 +307,7 @@ func testConcurrentOperations(t *testing.T, ctx context.Context, index Index) {
 			for operationIndex := 0; operationIndex < 10; operationIndex++ {
 				switch operationIndex % 3 {
 				case 0: // Add
-					entries := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-%d-%d", id, operationIndex), DeviceTier: "gpu"}}
+					entries := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-%d-%d", id, operationIndex), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}}
 					if err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, entries); err != nil {
 						errChan <- err
 					}
@@ -316,7 +317,7 @@ func testConcurrentOperations(t *testing.T, ctx context.Context, index Index) {
 						errChan <- err
 					}
 				case 2: // Evict
-					entries := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-%d-%d", id, operationIndex-2), DeviceTier: "gpu"}}
+					entries := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-%d-%d", id, operationIndex-2), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}}
 					if err := index.Evict(ctx, engineKey, EngineKey, entries); err != nil {
 						errChan <- err
 					}
@@ -360,7 +361,7 @@ func testStressConcurrentAddOverlappingKeys(t *testing.T, ctx context.Context, i
 		go func(id int) {
 			defer wg.Done()
 			for k := range numKeys {
-				entry := PodEntry{PodIdentifier: fmt.Sprintf("pod-%d", id), DeviceTier: "gpu"}
+				entry := PodEntry{PodIdentifier: fmt.Sprintf("pod-%d", id), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 				if err := index.Add(ctx, []BlockHash{engineKeys[k]}, []BlockHash{requestKeys[k]}, []PodEntry{entry}); err != nil {
 					errChan <- fmt.Errorf("goroutine %d key %d: Add failed: %w", id, k, err)
 				}
@@ -392,7 +393,7 @@ func testStressConcurrentAddEvictInterleaved(t *testing.T, ctx context.Context, 
 	requestKey := BlockHash(7200000)
 
 	// Seed the index so evictions have something to remove.
-	seed := PodEntry{PodIdentifier: "seed-pod", DeviceTier: "gpu"}
+	seed := PodEntry{PodIdentifier: "seed-pod", DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 	require.NoError(t, index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, []PodEntry{seed}))
 
 	var wg sync.WaitGroup
@@ -405,7 +406,7 @@ func testStressConcurrentAddEvictInterleaved(t *testing.T, ctx context.Context, 
 		go func(id int) {
 			defer wg.Done()
 			for i := range numIterations {
-				entry := PodEntry{PodIdentifier: fmt.Sprintf("add-%d-%d", id, i), DeviceTier: "gpu"}
+				entry := PodEntry{PodIdentifier: fmt.Sprintf("add-%d-%d", id, i), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 				if err := index.Add(ctx, []BlockHash{engineKey}, []BlockHash{requestKey}, []PodEntry{entry}); err != nil {
 					errChan <- err
 				}
@@ -416,7 +417,7 @@ func testStressConcurrentAddEvictInterleaved(t *testing.T, ctx context.Context, 
 		go func(id int) {
 			defer wg.Done()
 			for i := range numIterations {
-				entry := PodEntry{PodIdentifier: fmt.Sprintf("add-%d-%d", id, i), DeviceTier: "gpu"}
+				entry := PodEntry{PodIdentifier: fmt.Sprintf("add-%d-%d", id, i), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 				if err := index.Evict(ctx, engineKey, EngineKey, []PodEntry{entry}); err != nil {
 					errChan <- err
 				}
@@ -460,7 +461,7 @@ func testStressConcurrentAddLookup(t *testing.T, ctx context.Context, index Inde
 			defer wg.Done()
 			for i := range numIterations {
 				k := i % len(requestKeys)
-				entry := PodEntry{PodIdentifier: fmt.Sprintf("w-%d-%d", id, i), DeviceTier: "gpu"}
+				entry := PodEntry{PodIdentifier: fmt.Sprintf("w-%d-%d", id, i), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 				if err := index.Add(ctx, []BlockHash{engineKeys[k]}, []BlockHash{requestKeys[k]}, []PodEntry{entry}); err != nil {
 					errChan <- err
 				}
@@ -502,8 +503,8 @@ func testStressConcurrentEvictDuringLookup(t *testing.T, ctx context.Context, in
 		requestKeys[i] = BlockHash(uint64(5100000) + uint64(i)) // #nosec G115 -- test data, i is small
 		engineKeys[i] = BlockHash(uint64(5200000) + uint64(i))  // #nosec G115 -- test data, i is small
 		entries := []PodEntry{
-			{PodIdentifier: fmt.Sprintf("pod-a-%d", i), DeviceTier: "gpu"},
-			{PodIdentifier: fmt.Sprintf("pod-b-%d", i), DeviceTier: "gpu"},
+			{PodIdentifier: fmt.Sprintf("pod-a-%d", i), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
+			{PodIdentifier: fmt.Sprintf("pod-b-%d", i), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank},
 		}
 		require.NoError(t, index.Add(ctx, []BlockHash{engineKeys[i]}, []BlockHash{requestKeys[i]}, entries))
 	}
@@ -517,7 +518,7 @@ func testStressConcurrentEvictDuringLookup(t *testing.T, ctx context.Context, in
 		go func() {
 			defer wg.Done()
 			for k := range numKeys {
-				entry := PodEntry{PodIdentifier: fmt.Sprintf("pod-a-%d", k), DeviceTier: "gpu"}
+				entry := PodEntry{PodIdentifier: fmt.Sprintf("pod-a-%d", k), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 				if err := index.Evict(ctx, engineKeys[k], EngineKey, []PodEntry{entry}); err != nil {
 					errChan <- err
 				}
@@ -575,7 +576,7 @@ func testStressHighCardinality(t *testing.T, ctx context.Context, index Index) {
 				k := (id*7 + i) % numKeys // spread access across keys
 				switch i % 3 {
 				case 0:
-					entry := PodEntry{PodIdentifier: fmt.Sprintf("hc-%d", id), DeviceTier: "gpu"}
+					entry := PodEntry{PodIdentifier: fmt.Sprintf("hc-%d", id), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 					if err := index.Add(ctx, []BlockHash{engineKeys[k]}, []BlockHash{requestKeys[k]}, []PodEntry{entry}); err != nil {
 						errChan <- err
 						return
@@ -586,7 +587,7 @@ func testStressHighCardinality(t *testing.T, ctx context.Context, index Index) {
 						return
 					}
 				case 2:
-					entry := PodEntry{PodIdentifier: fmt.Sprintf("hc-%d", id), DeviceTier: "gpu"}
+					entry := PodEntry{PodIdentifier: fmt.Sprintf("hc-%d", id), DeviceTier: "gpu", DataParallelRank: NoDataParallelRank}
 					if err := index.Evict(ctx, engineKeys[k], EngineKey, []PodEntry{entry}); err != nil {
 						errChan <- err
 						return
@@ -742,7 +743,7 @@ func testEvictOneToOne(t *testing.T, ctx context.Context, index Index) {
 func testAddWithNilEngineKeys(t *testing.T, ctx context.Context, index Index) {
 	t.Helper()
 	requestKey := BlockHash(55555555)
-	pod := PodEntry{PodIdentifier: "10.0.0.3:8080", Speculative: true}
+	pod := PodEntry{PodIdentifier: "10.0.0.3:8080", Speculative: true, DataParallelRank: NoDataParallelRank}
 
 	// Add with nil engineKeys should not panic or error
 	err := index.Add(ctx, nil, []BlockHash{requestKey}, []PodEntry{pod})

--- a/pkg/kvcache/kvblock/traced_index_test.go
+++ b/pkg/kvcache/kvblock/traced_index_test.go
@@ -53,8 +53,8 @@ func TestTracedIndexBehavior(t *testing.T) {
 	engineKey := kvblock.BlockHash(123)
 	requestKey := kvblock.BlockHash(789)
 	entries := []kvblock.PodEntry{
-		{PodIdentifier: "pod1", DeviceTier: "gpu"},
-		{PodIdentifier: "pod2", DeviceTier: "cpu"},
+		{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+		{PodIdentifier: "pod2", DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank},
 	}
 
 	err = tracedIdx.Add(ctx, []kvblock.BlockHash{engineKey}, []kvblock.BlockHash{requestKey}, entries)
@@ -88,7 +88,7 @@ func TestTracedIndexCacheHitMetrics(t *testing.T) {
 	// Add some data
 	engineKeys := []kvblock.BlockHash{kvblock.BlockHash(1)}
 	requestKeys := []kvblock.BlockHash{kvblock.BlockHash(2)}
-	entries := []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}}
+	entries := []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}}
 
 	err = tracedIdx.Add(ctx, engineKeys, requestKeys, entries)
 	require.NoError(t, err)

--- a/pkg/kvcache/kvblock_scorer.go
+++ b/pkg/kvcache/kvblock_scorer.go
@@ -19,6 +19,8 @@ package kvcache
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 )
@@ -51,7 +53,9 @@ type KVBlockScorer interface {
 	// Strategy returns the scoring strategy type.
 	Strategy() KVScoringStrategy
 	// Score scores the blocks based on the scoring strategy.
-	// It returns a map of pod names to their scores.
+	// The returned map is keyed by pod scoring key (not the raw pod identifier):
+	// for non-DP pods the key is the pod identifier; for DP-aware pods the key is
+	// "<pod>@dp<rank>". Use ParsePodScoringKey to decompose these keys.
 	Score(ctx context.Context, keys []kvblock.BlockHash,
 		keyToPods map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error)
 }
@@ -86,6 +90,50 @@ func (s *LongestPrefixScorer) Strategy() KVScoringStrategy {
 	return LongestPrefixMatch
 }
 
+// podScoringKey returns a scoring identity for a PodEntry.
+// It combines PodIdentifier and DataParallelRank:
+//   - "pod-1" when DataParallelRank == NoDataParallelRank (backward compatible)
+//   - "pod-1@dp0" when DataParallelRank == 0
+func podScoringKey(entry kvblock.PodEntry) string {
+	if entry.DataParallelRank == kvblock.NoDataParallelRank {
+		return entry.PodIdentifier
+	}
+	return entry.PodIdentifier + "@dp" + strconv.Itoa(entry.DataParallelRank)
+}
+
+// ParsePodScoringKey decomposes a scoring key produced by podScoringKey into
+// its pod identifier and optional DP rank. It is the inverse of podScoringKey
+// and MUST be the only place that interprets the scoring-key format, so the
+// encoding and decoding rules cannot drift.
+//
+// Behavior:
+//   - "pod-1"        -> ("pod-1", nil)          // non-DP
+//   - "pod-1@dp0"    -> ("pod-1", *int32 = 0)   // DP rank 0
+//   - "pod-1@dp7"    -> ("pod-1", *int32 = 7)   // DP rank 7
+//   - "pod@dp"       -> ("pod@dp", nil)         // malformed: no digits
+//   - "pod@dpXYZ"    -> ("pod@dpXYZ", nil)      // malformed: non-digit suffix
+//   - "pod@dp-1"     -> ("pod@dp-1", nil)       // malformed: negative rank
+//
+// The caller must treat a nil rank as "non-DP deployment"; a returned zero
+// value (*rank == 0) is a valid DP rank, not "absent". Negative ranks are
+// treated as malformed (not returned) because the proto contract and
+// podScoringKey only ever produce non-negative ranks.
+func ParsePodScoringKey(scoringKey string) (pod string, dpRank *int32) {
+	idx := strings.LastIndex(scoringKey, "@dp")
+	if idx < 0 {
+		return scoringKey, nil
+	}
+	rank, err := strconv.ParseInt(scoringKey[idx+3:], 10, 32)
+	if err != nil || rank < 0 {
+		// "@dp" not followed by a non-negative integer — treat entire string
+		// as pod name so a malformed key cannot leak a negative rank across
+		// the gRPC boundary.
+		return scoringKey, nil
+	}
+	r := int32(rank)
+	return scoringKey[:idx], &r
+}
+
 // fillMaxWeights populates dst with the maximum weight per podID across all
 // device tiers for the given entries. The caller must clear dst before calling.
 func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWeights map[string]float64) {
@@ -96,13 +144,16 @@ func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWe
 				weight = w
 			}
 		}
-		if cur, exists := dst[entry.PodIdentifier]; !exists || weight > cur {
-			dst[entry.PodIdentifier] = weight
+		key := podScoringKey(entry)
+		if cur, exists := dst[key]; !exists || weight > cur {
+			dst[key] = weight
 		}
 	}
 }
 
 // Score implements the longest prefix scoring logic with weighted sum based on BackendConfig.
+// The returned map keys are scoring keys that encode the pod identifier and, when applicable,
+// the data parallel rank (e.g., "pod-1" or "pod-1@dp0").
 func (s *LongestPrefixScorer) Score(
 	_ context.Context,
 	keys []kvblock.BlockHash,

--- a/pkg/kvcache/kvblock_scorer.go
+++ b/pkg/kvcache/kvblock_scorer.go
@@ -19,8 +19,6 @@ package kvcache
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 )
@@ -53,11 +51,16 @@ type KVBlockScorer interface {
 	// Strategy returns the scoring strategy type.
 	Strategy() KVScoringStrategy
 	// Score scores the blocks based on the scoring strategy.
-	// The returned map is keyed by pod scoring key (not the raw pod identifier):
-	// for non-DP pods the key is the pod identifier; for DP-aware pods the key is
-	// "<pod>@dp<rank>". Use ParsePodScoringKey to decompose these keys.
+	//
+	// The returned map is keyed by a kvblock.PodEntry that carries only the
+	// scoring identity: PodIdentifier and DataParallelRank (NoDataParallelRank
+	// for non-DP pods). DeviceTier and Speculative are intentionally left at
+	// their zero values because scores are aggregated (max-weighted) across
+	// device tiers for the same (pod, rank). Callers should read
+	// PodIdentifier / DataParallelRank from the key directly rather than
+	// parsing strings.
 	Score(ctx context.Context, keys []kvblock.BlockHash,
-		keyToPods map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error)
+		keyToPods map[kvblock.BlockHash][]kvblock.PodEntry) (map[kvblock.PodEntry]float64, error)
 }
 
 // NewKVBlockScorer creates a new KVBlockScorer based on the provided strategy.
@@ -90,53 +93,21 @@ func (s *LongestPrefixScorer) Strategy() KVScoringStrategy {
 	return LongestPrefixMatch
 }
 
-// podScoringKey returns a scoring identity for a PodEntry.
-// It combines PodIdentifier and DataParallelRank:
-//   - "pod-1" when DataParallelRank == NoDataParallelRank (backward compatible)
-//   - "pod-1@dp0" when DataParallelRank == 0
-func podScoringKey(entry kvblock.PodEntry) string {
-	if entry.DataParallelRank == kvblock.NoDataParallelRank {
-		return entry.PodIdentifier
+// scoringKey returns the PodEntry that identifies a scoring target. Only
+// PodIdentifier and DataParallelRank are retained; DeviceTier and Speculative
+// are cleared so that the same (pod, rank) aggregates across device tiers
+// instead of producing one map entry per tier.
+func scoringKey(entry kvblock.PodEntry) kvblock.PodEntry {
+	return kvblock.PodEntry{
+		PodIdentifier:    entry.PodIdentifier,
+		DataParallelRank: entry.DataParallelRank,
 	}
-	return entry.PodIdentifier + "@dp" + strconv.Itoa(entry.DataParallelRank)
 }
 
-// ParsePodScoringKey decomposes a scoring key produced by podScoringKey into
-// its pod identifier and optional DP rank. It is the inverse of podScoringKey
-// and MUST be the only place that interprets the scoring-key format, so the
-// encoding and decoding rules cannot drift.
-//
-// Behavior:
-//   - "pod-1"        -> ("pod-1", nil)          // non-DP
-//   - "pod-1@dp0"    -> ("pod-1", *int32 = 0)   // DP rank 0
-//   - "pod-1@dp7"    -> ("pod-1", *int32 = 7)   // DP rank 7
-//   - "pod@dp"       -> ("pod@dp", nil)         // malformed: no digits
-//   - "pod@dpXYZ"    -> ("pod@dpXYZ", nil)      // malformed: non-digit suffix
-//   - "pod@dp-1"     -> ("pod@dp-1", nil)       // malformed: negative rank
-//
-// The caller must treat a nil rank as "non-DP deployment"; a returned zero
-// value (*rank == 0) is a valid DP rank, not "absent". Negative ranks are
-// treated as malformed (not returned) because the proto contract and
-// podScoringKey only ever produce non-negative ranks.
-func ParsePodScoringKey(scoringKey string) (pod string, dpRank *int32) {
-	idx := strings.LastIndex(scoringKey, "@dp")
-	if idx < 0 {
-		return scoringKey, nil
-	}
-	rank, err := strconv.ParseInt(scoringKey[idx+3:], 10, 32)
-	if err != nil || rank < 0 {
-		// "@dp" not followed by a non-negative integer — treat entire string
-		// as pod name so a malformed key cannot leak a negative rank across
-		// the gRPC boundary.
-		return scoringKey, nil
-	}
-	r := int32(rank)
-	return scoringKey[:idx], &r
-}
-
-// fillMaxWeights populates dst with the maximum weight per podID across all
-// device tiers for the given entries. The caller must clear dst before calling.
-func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWeights map[string]float64) {
+// fillMaxWeights populates dst with the maximum weight per (pod, rank) across
+// all device tiers for the given entries. The caller must clear dst before
+// calling.
+func fillMaxWeights(dst map[kvblock.PodEntry]float64, entries []kvblock.PodEntry, mediumWeights map[string]float64) {
 	for _, entry := range entries {
 		weight := 1.0
 		if mediumWeights != nil {
@@ -144,7 +115,7 @@ func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWe
 				weight = w
 			}
 		}
-		key := podScoringKey(entry)
+		key := scoringKey(entry)
 		if cur, exists := dst[key]; !exists || weight > cur {
 			dst[key] = weight
 		}
@@ -152,21 +123,21 @@ func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWe
 }
 
 // Score implements the longest prefix scoring logic with weighted sum based on BackendConfig.
-// The returned map keys are scoring keys that encode the pod identifier and, when applicable,
-// the data parallel rank (e.g., "pod-1" or "pod-1@dp0").
+// The returned map keys are kvblock.PodEntry values carrying the pod identifier and, when
+// applicable, the data parallel rank (DeviceTier/Speculative are left zeroed).
 func (s *LongestPrefixScorer) Score(
 	_ context.Context,
 	keys []kvblock.BlockHash,
 	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
-) (map[string]float64, error) {
+) (map[kvblock.PodEntry]float64, error) {
 	if len(keys) == 0 {
-		return make(map[string]float64), nil
+		return make(map[kvblock.PodEntry]float64), nil
 	}
 
-	podScores := make(map[string]float64)
+	podScores := make(map[kvblock.PodEntry]float64)
 
 	// Scratch map reused across iterations to avoid per-key allocation.
-	curWeights := make(map[string]float64)
+	curWeights := make(map[kvblock.PodEntry]float64)
 
 	// Build weight index for the first key in a single pass over entries.
 	fillMaxWeights(curWeights, keyToPods[keys[0]], s.MediumWeights)
@@ -174,7 +145,7 @@ func (s *LongestPrefixScorer) Score(
 	// activePods tracks pods still in the consecutive prefix chain.
 	// Using a plain map and in-place deletion avoids allocating new sets
 	// on every iteration.
-	activePods := make(map[string]struct{}, len(curWeights))
+	activePods := make(map[kvblock.PodEntry]struct{}, len(curWeights))
 	for pod, w := range curWeights {
 		activePods[pod] = struct{}{}
 		podScores[pod] = w

--- a/pkg/kvcache/kvblock_scorer_test.go
+++ b/pkg/kvcache/kvblock_scorer_test.go
@@ -44,15 +44,15 @@ func TestLongestPrefixScorer(t *testing.T) {
 	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002, 1003, 1004, 1005, 1006})
 
 	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
-		1001: {{PodIdentifier: podA, DeviceTier: "gpu"}},
-		1002: {{PodIdentifier: podA, DeviceTier: "gpu"}},
+		1001: {{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		1002: {{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 		1003: {
-			{PodIdentifier: podA, DeviceTier: "gpu"},
-			{PodIdentifier: podA, DeviceTier: "cpu"},
+			{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+			{PodIdentifier: podA, DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank},
 		},
-		1004: {{PodIdentifier: podB, DeviceTier: "cpu"}},
-		1005: {{PodIdentifier: podB, DeviceTier: "cpu"}},
-		1006: {{PodIdentifier: podA, DeviceTier: "gpu"}},
+		1004: {{PodIdentifier: podB, DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		1005: {{PodIdentifier: podB, DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		1006: {{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 	}
 
 	expected := map[string]float64{
@@ -79,12 +79,12 @@ func TestLongestPrefixScorerDifferentTiers(t *testing.T) {
 	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002, 1003, 1004, 1005, 1006})
 
 	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
-		1001: {{PodIdentifier: podA, DeviceTier: "gpu"}},
-		1002: {{PodIdentifier: podA, DeviceTier: "gpu"}},
-		1003: {{PodIdentifier: podA, DeviceTier: "cpu"}},
-		1004: {{PodIdentifier: podB, DeviceTier: "cpu"}},
-		1005: {{PodIdentifier: podB, DeviceTier: "cpu"}},
-		1006: {{PodIdentifier: podA, DeviceTier: "gpu"}},
+		1001: {{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		1002: {{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		1003: {{PodIdentifier: podA, DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		1004: {{PodIdentifier: podB, DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		1005: {{PodIdentifier: podB, DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank}},
+		1006: {{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 	}
 
 	expected := map[string]float64{
@@ -99,10 +99,119 @@ func TestLongestPrefixScorerDifferentTiers(t *testing.T) {
 	}
 }
 
+// TestLongestPrefixScorerWithDPRanks verifies that different DP ranks on the same pod
+// are scored as separate routing targets.
+func TestLongestPrefixScorerWithDPRanks(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 1.0,
+	}
+
+	scorer := &kvcache.LongestPrefixScorer{
+		MediumWeights: mediumWeights,
+	}
+	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002, 1003})
+
+	// Same pod, different DP ranks have different blocks cached
+	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {
+			{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: 0},
+			{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: 1},
+		},
+		1002: {
+			{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: 0},
+		},
+		1003: {
+			{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: 1},
+		},
+	}
+
+	// podA@dp0 has blocks 1001+1002 (consecutive from start) → score 2.0
+	// podA@dp1 has blocks 1001 only (1002 breaks the chain) → score 1.0
+	expected := map[string]float64{
+		"pod-a@dp0": 2.0,
+		"pod-a@dp1": 1.0,
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.Len(t, scored, 2)
+	for pod, score := range scored {
+		assert.InDelta(t, expected[pod], score, 0.0001, "pod=%s", pod)
+	}
+}
+
+// TestLongestPrefixScorerMixedDPAndNonDP verifies that non-DP pods (rank=-1)
+// and DP-aware pods (rank>=0) can coexist in the same scoring run.
+func TestLongestPrefixScorerMixedDPAndNonDP(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 1.0,
+	}
+
+	scorer := &kvcache.LongestPrefixScorer{
+		MediumWeights: mediumWeights,
+	}
+	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002})
+
+	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {
+			{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: 0},
+			{PodIdentifier: podB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+		},
+		1002: {
+			{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: 0},
+			{PodIdentifier: podB, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+		},
+	}
+
+	// podA@dp0 and podB (no DP) both have all blocks → both score 2.0
+	expected := map[string]float64{
+		"pod-a@dp0": 2.0,
+		podB:        2.0,
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.Len(t, scored, 2)
+	for pod, score := range scored {
+		assert.InDelta(t, expected[pod], score, 0.0001, "pod=%s", pod)
+	}
+}
+
 func int64KeysToKVBlockKeys(keys []uint64) []kvblock.BlockHash {
 	kvKeys := make([]kvblock.BlockHash, len(keys))
 	for i, key := range keys {
 		kvKeys[i] = kvblock.BlockHash(key)
 	}
 	return kvKeys
+}
+
+func TestParsePodScoringKey(t *testing.T) {
+	i32 := func(v int32) *int32 { return &v }
+	cases := []struct {
+		key     string
+		wantPod string
+		wantDP  *int32
+	}{
+		{"pod-1", "pod-1", nil},              // non-DP
+		{"pod-1@dp0", "pod-1", i32(0)},       // DP rank 0 (must NOT be collapsed to non-DP)
+		{"pod-1@dp1", "pod-1", i32(1)},       // DP rank 1
+		{"pod-1@dp42", "pod-1", i32(42)},     // multi-digit rank
+		{"pod@dp", "pod@dp", nil},            // malformed: no digits after @dp
+		{"pod@dpXYZ", "pod@dpXYZ", nil},      // malformed: non-digit suffix
+		{"pod@dp-1", "pod@dp-1", nil},        // malformed: negative rank not allowed
+		{"pod@dp-42", "pod@dp-42", nil},      // malformed: multi-digit negative rank
+		{"host@dp0@dp1", "host@dp0", i32(1)}, // LastIndex: innermost @dp wins
+		{"", "", nil},                        // empty
+	}
+	for _, tc := range cases {
+		pod, dp := kvcache.ParsePodScoringKey(tc.key)
+		assert.Equal(t, tc.wantPod, pod, "pod for %q", tc.key)
+		if tc.wantDP == nil {
+			assert.Nil(t, dp, "dpRank for %q should be nil", tc.key)
+		} else {
+			if assert.NotNil(t, dp, "dpRank for %q should not be nil", tc.key) {
+				assert.Equal(t, *tc.wantDP, *dp, "dpRank for %q", tc.key)
+			}
+		}
+	}
 }

--- a/pkg/kvcache/kvblock_scorer_test.go
+++ b/pkg/kvcache/kvblock_scorer_test.go
@@ -55,9 +55,9 @@ func TestLongestPrefixScorer(t *testing.T) {
 		1006: {{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 	}
 
-	expected := map[string]float64{
-		podA: 3.0,
-		podB: 0.0,
+	expected := map[kvblock.PodEntry]float64{
+		nonDPScoreKey(podA): 3.0,
+		nonDPScoreKey(podB): 0.0,
 	}
 
 	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
@@ -87,9 +87,9 @@ func TestLongestPrefixScorerDifferentTiers(t *testing.T) {
 		1006: {{PodIdentifier: podA, DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}},
 	}
 
-	expected := map[string]float64{
-		podA: 2.5,
-		podB: 0.0,
+	expected := map[kvblock.PodEntry]float64{
+		nonDPScoreKey(podA): 2.5,
+		nonDPScoreKey(podB): 0.0,
 	}
 
 	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
@@ -127,9 +127,9 @@ func TestLongestPrefixScorerWithDPRanks(t *testing.T) {
 
 	// podA@dp0 has blocks 1001+1002 (consecutive from start) → score 2.0
 	// podA@dp1 has blocks 1001 only (1002 breaks the chain) → score 1.0
-	expected := map[string]float64{
-		"pod-a@dp0": 2.0,
-		"pod-a@dp1": 1.0,
+	expected := map[kvblock.PodEntry]float64{
+		dpScoreKey(podA, 0): 2.0,
+		dpScoreKey(podA, 1): 1.0,
 	}
 
 	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
@@ -164,9 +164,9 @@ func TestLongestPrefixScorerMixedDPAndNonDP(t *testing.T) {
 	}
 
 	// podA@dp0 and podB (no DP) both have all blocks → both score 2.0
-	expected := map[string]float64{
-		"pod-a@dp0": 2.0,
-		podB:        2.0,
+	expected := map[kvblock.PodEntry]float64{
+		dpScoreKey(podA, 0): 2.0,
+		nonDPScoreKey(podB): 2.0,
 	}
 
 	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
@@ -183,35 +183,4 @@ func int64KeysToKVBlockKeys(keys []uint64) []kvblock.BlockHash {
 		kvKeys[i] = kvblock.BlockHash(key)
 	}
 	return kvKeys
-}
-
-func TestParsePodScoringKey(t *testing.T) {
-	i32 := func(v int32) *int32 { return &v }
-	cases := []struct {
-		key     string
-		wantPod string
-		wantDP  *int32
-	}{
-		{"pod-1", "pod-1", nil},              // non-DP
-		{"pod-1@dp0", "pod-1", i32(0)},       // DP rank 0 (must NOT be collapsed to non-DP)
-		{"pod-1@dp1", "pod-1", i32(1)},       // DP rank 1
-		{"pod-1@dp42", "pod-1", i32(42)},     // multi-digit rank
-		{"pod@dp", "pod@dp", nil},            // malformed: no digits after @dp
-		{"pod@dpXYZ", "pod@dpXYZ", nil},      // malformed: non-digit suffix
-		{"pod@dp-1", "pod@dp-1", nil},        // malformed: negative rank not allowed
-		{"pod@dp-42", "pod@dp-42", nil},      // malformed: multi-digit negative rank
-		{"host@dp0@dp1", "host@dp0", i32(1)}, // LastIndex: innermost @dp wins
-		{"", "", nil},                        // empty
-	}
-	for _, tc := range cases {
-		pod, dp := kvcache.ParsePodScoringKey(tc.key)
-		assert.Equal(t, tc.wantPod, pod, "pod for %q", tc.key)
-		if tc.wantDP == nil {
-			assert.Nil(t, dp, "dpRank for %q should be nil", tc.key)
-		} else {
-			if assert.NotNil(t, dp, "dpRank for %q should not be nil", tc.key) {
-				assert.Equal(t, *tc.wantDP, *dp, "dpRank for %q", tc.key)
-			}
-		}
-	}
 }

--- a/pkg/kvcache/traced_scorer.go
+++ b/pkg/kvcache/traced_scorer.go
@@ -46,7 +46,7 @@ func (t *tracedScorer) Score(
 	ctx context.Context,
 	keys []kvblock.BlockHash,
 	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
-) (map[string]float64, error) {
+) (map[kvblock.PodEntry]float64, error) {
 	tracer := otel.Tracer(telemetry.InstrumentationName)
 	_, span := tracer.Start(ctx, "llm_d.kv_cache.scorer.compute",
 		trace.WithSpanKind(trace.SpanKindInternal),

--- a/pkg/kvcache/traced_scorer_test.go
+++ b/pkg/kvcache/traced_scorer_test.go
@@ -58,14 +58,14 @@ func TestTracedScorerBehavior(t *testing.T) {
 
 	keyToPods := map[kvblock.BlockHash][]kvblock.PodEntry{
 		kvblock.BlockHash(1): {
-			{PodIdentifier: "pod1", DeviceTier: "gpu"},
-			{PodIdentifier: "pod2", DeviceTier: "cpu"},
+			{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+			{PodIdentifier: "pod2", DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank},
 		},
 		kvblock.BlockHash(2): {
-			{PodIdentifier: "pod1", DeviceTier: "gpu"},
+			{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 		},
 		kvblock.BlockHash(3): {
-			{PodIdentifier: "pod1", DeviceTier: "gpu"},
+			{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 		},
 	}
 
@@ -105,12 +105,12 @@ func TestTracedScorerScoreDistribution(t *testing.T) {
 
 	keyToPods := map[kvblock.BlockHash][]kvblock.PodEntry{
 		kvblock.BlockHash(1): {
-			{PodIdentifier: "pod1", DeviceTier: "gpu"},
-			{PodIdentifier: "pod2", DeviceTier: "gpu"},
-			{PodIdentifier: "pod3", DeviceTier: "cpu"},
+			{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+			{PodIdentifier: "pod2", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
+			{PodIdentifier: "pod3", DeviceTier: "cpu", DataParallelRank: kvblock.NoDataParallelRank},
 		},
 		kvblock.BlockHash(2): {
-			{PodIdentifier: "pod1", DeviceTier: "gpu"},
+			{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank},
 		},
 	}
 

--- a/pkg/kvcache/traced_scorer_test.go
+++ b/pkg/kvcache/traced_scorer_test.go
@@ -74,7 +74,7 @@ func TestTracedScorerBehavior(t *testing.T) {
 	require.NotNil(t, scores)
 
 	// pod1 should have highest score (appears in all 3 keys)
-	require.Greater(t, scores["pod1"], scores["pod2"])
+	require.Greater(t, scores[nonDPScoreKey("pod1")], scores[nonDPScoreKey("pod2")])
 }
 
 func TestTracedScorerWithEmptyData(t *testing.T) {
@@ -119,6 +119,6 @@ func TestTracedScorerScoreDistribution(t *testing.T) {
 	require.Len(t, scores, 3)
 
 	// Verify pod1 has highest score
-	require.Greater(t, scores["pod1"], scores["pod2"])
-	require.Greater(t, scores["pod1"], scores["pod3"])
+	require.Greater(t, scores[nonDPScoreKey("pod1")], scores[nonDPScoreKey("pod2")])
+	require.Greater(t, scores[nonDPScoreKey("pod1")], scores[nonDPScoreKey("pod3")])
 }

--- a/pkg/kvevents/engineadapter/sglang_adapter.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter.go
@@ -68,19 +68,19 @@ func (s *SGLangAdapter) ShardingKey(msg *kvevents.RawMessage) string {
 // and decodes the msgpack payload into an EventBatch.
 //
 //nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
-func (s *SGLangAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, kvevents.EventBatch, error) {
+func (s *SGLangAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, kvevents.EventBatch, *int, error) {
 	podID, modelName := parseTopic(msg.Topic)
 
 	var batch msgpackSGLangEventBatch
 	if err := msgpack.Unmarshal(msg.Payload, &batch); err != nil {
-		return "", "", kvevents.EventBatch{}, fmt.Errorf("failed to decode SGLang event batch: %w", err)
+		return "", "", kvevents.EventBatch{}, nil, fmt.Errorf("failed to decode SGLang event batch: %w", err)
 	}
 
 	genericEvents := make([]kvevents.GenericEvent, len(batch.Events))
 	for i, rawEventBytes := range batch.Events {
 		genericEvent, err := decodeEvent(rawEventBytes, s.eventConverters)
 		if err != nil {
-			return "", "", kvevents.EventBatch{}, fmt.Errorf("failed to decode SGLang event: %w", err)
+			return "", "", kvevents.EventBatch{}, nil, fmt.Errorf("failed to decode SGLang event: %w", err)
 		}
 		genericEvents[i] = genericEvent
 	}
@@ -90,7 +90,7 @@ func (s *SGLangAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, 
 		Events:    genericEvents,
 	}
 
-	return podID, modelName, eventBatch, nil
+	return podID, modelName, eventBatch, batch.DataParallelRank, nil
 }
 
 // SGLang msgpack event structures.

--- a/pkg/kvevents/engineadapter/sglang_adapter_test.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter_test.go
@@ -61,7 +61,7 @@ func TestSGLangParseMessage_Valid(t *testing.T) {
 		Payload:  payload,
 	}
 
-	podID, modelName, eventBatch, err := adapter.ParseMessage(msg)
+	podID, modelName, eventBatch, _, err := adapter.ParseMessage(msg)
 	require.NoError(t, err)
 	assert.Equal(t, "pod-1", podID)
 	assert.Equal(t, "llama-2-7b", modelName)
@@ -82,7 +82,7 @@ func TestSGLangParseMessage_InvalidPayload(t *testing.T) {
 		Payload: []byte{0xFF, 0xFF, 0xFF},
 	}
 
-	_, _, _, err := adapter.ParseMessage(msg)
+	_, _, _, _, err := adapter.ParseMessage(msg)
 	assert.Error(t, err)
 }
 

--- a/pkg/kvevents/engineadapter/vllm_adapter.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter.go
@@ -61,19 +61,19 @@ func (v *VLLMAdapter) ShardingKey(msg *kvevents.RawMessage) string {
 // and decodes the msgpack payload into an EventBatch.
 //
 //nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
-func (v *VLLMAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, kvevents.EventBatch, error) {
+func (v *VLLMAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, kvevents.EventBatch, *int, error) {
 	podID, modelName := parseTopic(msg.Topic)
 
 	var vllmBatch msgpackVLLMEventBatch
 	if err := msgpack.Unmarshal(msg.Payload, &vllmBatch); err != nil {
-		return "", "", kvevents.EventBatch{}, fmt.Errorf("failed to decode vLLM event batch: %w", err)
+		return "", "", kvevents.EventBatch{}, nil, fmt.Errorf("failed to decode vLLM event batch: %w", err)
 	}
 
 	genericEvents := make([]kvevents.GenericEvent, len(vllmBatch.Events))
 	for i, rawEventBytes := range vllmBatch.Events {
 		genericEvent, err := v.decodeVLLMEvent(rawEventBytes)
 		if err != nil {
-			return "", "", kvevents.EventBatch{}, fmt.Errorf("failed to decode vLLM event: %w", err)
+			return "", "", kvevents.EventBatch{}, nil, fmt.Errorf("failed to decode vLLM event: %w", err)
 		}
 		genericEvents[i] = genericEvent
 	}
@@ -83,7 +83,7 @@ func (v *VLLMAdapter) ParseMessage(msg *kvevents.RawMessage) (string, string, kv
 		Events:    genericEvents,
 	}
 
-	return podID, modelName, batch, nil
+	return podID, modelName, batch, vllmBatch.DataParallelRank, nil
 }
 
 // vLLM msgpack event batch structure.

--- a/pkg/kvevents/engineadapter/vllm_adapter_bench_test.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter_bench_test.go
@@ -154,7 +154,7 @@ func BenchmarkParseMessage_Batch(b *testing.B) {
 			b.SetBytes(int64(len(batchPayload)))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, _, _, err := adapter.ParseMessage(msg)
+				_, _, _, _, err := adapter.ParseMessage(msg)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/kvevents/engineadapter/vllm_adapter_test.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter_test.go
@@ -62,10 +62,11 @@ func TestVLLMParseMessage_Valid(t *testing.T) {
 		Payload:  payload,
 	}
 
-	podID, modelName, eventBatch, err := adapter.ParseMessage(msg)
+	podID, modelName, eventBatch, dpRank, err := adapter.ParseMessage(msg)
 	require.NoError(t, err)
 	assert.Equal(t, "pod-1", podID)
 	assert.Equal(t, "llama-2-7b", modelName)
+	assert.Nil(t, dpRank, "DataParallelRank should be nil when not set")
 	assert.Len(t, eventBatch.Events, 1)
 
 	blockStored, ok := eventBatch.Events[0].(*kvevents.BlockStoredEvent)
@@ -83,8 +84,49 @@ func TestVLLMParseMessage_InvalidPayload(t *testing.T) {
 		Payload: []byte{0xFF, 0xFF, 0xFF},
 	}
 
-	_, _, _, err := adapter.ParseMessage(msg)
+	_, _, _, _, err := adapter.ParseMessage(msg)
 	assert.Error(t, err)
+}
+
+// TestParseMessage_WithDataParallelRank tests that DataParallelRank is correctly
+// extracted from the msgpack payload when set by the vLLM engine.
+func TestParseMessage_WithDataParallelRank(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	blockStoredEvent := []any{
+		"BlockStored",
+		[]any{uint64(100)},
+		uint64(99),
+		[]uint32{1, 2},
+		16,
+		nil,
+		"gpu",
+		nil,
+		nil,
+	}
+
+	dpRankValue := 2
+	batch := []any{
+		1234567890.0,
+		[]any{blockStoredEvent},
+		dpRankValue,
+	}
+	payload, err := msgpack.Marshal(batch)
+	require.NoError(t, err)
+
+	msg := &kvevents.RawMessage{
+		Topic:    "kv@pod-1@llama-2-7b",
+		Sequence: 1,
+		Payload:  payload,
+	}
+
+	podID, modelName, eventBatch, dpRank, err := adapter.ParseMessage(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "pod-1", podID)
+	assert.Equal(t, "llama-2-7b", modelName)
+	require.NotNil(t, dpRank, "DataParallelRank should be set")
+	assert.Equal(t, dpRankValue, *dpRank)
+	assert.Len(t, eventBatch.Events, 1)
 }
 
 // TestVLLMBlockStored tests decoding a valid BlockStored event without LoRA.
@@ -600,7 +642,7 @@ func TestVLLMEventBatch_NestedArrayEvents(t *testing.T) {
 		Payload:  payload,
 	}
 
-	_, _, eventBatch, err := adapter.ParseMessage(msg)
+	_, _, eventBatch, _, err := adapter.ParseMessage(msg)
 	require.NoError(t, err)
 	require.Len(t, eventBatch.Events, 1)
 

--- a/pkg/kvevents/events.go
+++ b/pkg/kvevents/events.go
@@ -72,7 +72,7 @@ type EngineAdapter interface {
 	// ParseMessage parses a raw transport message into domain data.
 	// It extracts pod identity and model name from the topic,
 	// and decodes the payload into an EventBatch.
-	ParseMessage(msg *RawMessage) (podID, modelName string, batch EventBatch, err error)
+	ParseMessage(msg *RawMessage) (podID, modelName string, batch EventBatch, dataParallelRank *int, err error)
 
 	// ShardingKey extracts the key used to shard messages across worker queues.
 	// Messages with the same sharding key are guaranteed to be processed in order.

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -204,13 +204,13 @@ func (p *Pool) worker(ctx context.Context, workerIndex int) {
 func (p *Pool) processRawMessage(ctx context.Context, msg *RawMessage) {
 	logger := log.FromContext(ctx)
 
-	podID, modelName, batch, err := p.adapter.ParseMessage(msg)
+	podID, modelName, batch, dataParallelRank, err := p.adapter.ParseMessage(msg)
 	if err != nil {
 		logger.Error(err, "Failed to parse message")
 		return
 	}
 
-	p.processEventBatch(ctx, &batch, podID, modelName)
+	p.processEventBatch(ctx, &batch, podID, modelName, dataParallelRank)
 }
 
 // realignExtraFeatures converts per-engine-block extra features to per-canonical-block
@@ -296,7 +296,7 @@ func (p *Pool) handleDeviceTierUpdate(
 }
 
 // processEventBatch processes a batch of events using type switches.
-func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIdentifier, modelName string) {
+func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIdentifier, modelName string, dataParallelRank *int) {
 	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
 	debugLogger.V(logging.TRACE).Info("Processing event batch",
 		"podID", podIdentifier,
@@ -319,8 +319,8 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				effectiveModelName = *ev.LoraName
 			}
 
-			// Create PodEntry for this specific event's device tier.
-			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}
+			// Create PodEntry for this specific event's device tier and DP rank.
+			podEntries := []kvblock.PodEntry{kvblock.NewPodEntry(podIdentifier, deviceTier, dataParallelRank)}
 			if ev.GroupIdx != nil {
 				g := kvblock.GroupID(*ev.GroupIdx)
 				p.groupCatalog.Learn(podIdentifier, g, kvblock.GroupMetadata{
@@ -424,8 +424,8 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				deviceTier = strings.ToLower(ev.DeviceTier)
 			}
 
-			// Create PodEntry for this specific event's device tier.
-			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}
+			// Create PodEntry for this specific event's device tier and DP rank.
+			podEntries := []kvblock.PodEntry{kvblock.NewPodEntry(podIdentifier, deviceTier, dataParallelRank)}
 			if ev.GroupIdx != nil {
 				podEntries[0].HasGroup = true
 				podEntries[0].GroupIdx = kvblock.GroupID(*ev.GroupIdx)

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -675,7 +675,7 @@ func TestHMAGroupMetadataAndEntryOnBlockStored(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batch, "pod-hma", "test-model")
+	pool.processEventBatch(ctx, batch, "pod-hma", "test-model", nil)
 
 	meta, ok := pool.GroupCatalog().Get("pod-hma", kvblock.GroupID(0))
 	require.True(t, ok)
@@ -722,7 +722,7 @@ func TestHMAGroupLevelEviction_BlockRemoved(t *testing.T) {
 				},
 			},
 		}
-		pool.processEventBatch(ctx, batch, "pod-hma", "test-model")
+		pool.processEventBatch(ctx, batch, "pod-hma", "test-model", nil)
 	}
 
 	canonicalKeys, err := tp.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
@@ -747,7 +747,7 @@ func TestHMAGroupLevelEviction_BlockRemoved(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, removeBatch, "pod-hma", "test-model")
+	pool.processEventBatch(ctx, removeBatch, "pod-hma", "test-model", nil)
 
 	// Group 1 should remain; group 0 should be gone
 	result, err = idx.Lookup(ctx, canonicalKeys, nil)

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -71,7 +71,7 @@ func TestCanonicalWritePath_FallbackLegacy(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batch, "pod-legacy", "test-model")
+	pool.processEventBatch(ctx, batch, "pod-legacy", "test-model", nil)
 
 	// Verify engine->request mapping exists in the Index (legacy 1:1 path)
 	for _, ek := range engineKeys {
@@ -102,7 +102,7 @@ func TestCanonicalWritePath_ManyToOne(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batch, "pod-a", "test-model")
+	pool.processEventBatch(ctx, batch, "pod-a", "test-model", nil)
 
 	// Compute expected canonical keys independently
 	canonicalKeys, err := tp.TokensToKVBlockKeys(
@@ -150,7 +150,7 @@ func TestCanonicalWritePath_OneToMany(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batch, "pod-b", "test-model")
+	pool.processEventBatch(ctx, batch, "pod-b", "test-model", nil)
 
 	// Compute expected canonical keys independently
 	canonicalKeys, err := tp.TokensToKVBlockKeys(
@@ -184,7 +184,7 @@ func TestCanonicalWritePath_OneToMany(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, removeBatch, "pod-b", "test-model")
+	pool.processEventBatch(ctx, removeBatch, "pod-b", "test-model", nil)
 
 	for _, ck := range canonicalKeys[:2] {
 		result, err := idx.Lookup(ctx, []kvblock.BlockHash{ck}, nil)
@@ -221,7 +221,7 @@ func TestCanonicalEviction_Eager(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batch, "pod-a", "test-model")
+	pool.processEventBatch(ctx, batch, "pod-a", "test-model", nil)
 
 	canonicalKeys, err := tp.TokensToKVBlockKeys(
 		kvblock.EmptyBlockHash, tokens, "test-model", nil)
@@ -236,7 +236,7 @@ func TestCanonicalEviction_Eager(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, removeBatch, "pod-a", "test-model")
+	pool.processEventBatch(ctx, removeBatch, "pod-a", "test-model", nil)
 
 	// Verify canonical key 0 is evicted
 	result0, err := idx.Lookup(ctx, []kvblock.BlockHash{canonicalKeys[0]}, nil)
@@ -271,7 +271,7 @@ func TestCanonicalWritePath_CrossEngineScoring(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batchA, "pod-a", "test-model")
+	pool.processEventBatch(ctx, batchA, "pod-a", "test-model", nil)
 
 	// Engine B: block size 32, 4 engine keys
 	batchB := &EventBatch{
@@ -283,7 +283,7 @@ func TestCanonicalWritePath_CrossEngineScoring(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batchB, "pod-b", "test-model")
+	pool.processEventBatch(ctx, batchB, "pod-b", "test-model", nil)
 
 	// Both produce the same 2 canonical keys
 	canonicalKeys, err := tp.TokensToKVBlockKeys(
@@ -324,7 +324,7 @@ func TestCanonicalEviction_UnknownEngineKey(t *testing.T) {
 
 	// Should not panic or error, just skip
 	assert.NotPanics(t, func() {
-		pool.processEventBatch(ctx, removeBatch, "pod-x", "test-model")
+		pool.processEventBatch(ctx, removeBatch, "pod-x", "test-model", nil)
 	})
 }
 
@@ -419,7 +419,7 @@ func TestCanonicalWritePath_ExtraKeysOneToMany(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batch, "pod-extra", "test-model")
+	pool.processEventBatch(ctx, batch, "pod-extra", "test-model", nil)
 
 	// Compute expected canonical keys (no extra features for text-only)
 	canonicalKeys, err := tp.TokensToKVBlockKeys(
@@ -461,7 +461,7 @@ func TestCanonicalWritePath_ExtraKeysManyToOne(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batch, "pod-extra-m1", "test-model")
+	pool.processEventBatch(ctx, batch, "pod-extra-m1", "test-model", nil)
 
 	// Compute expected canonical keys (no extra features for text-only)
 	canonicalKeys, err := tp.TokensToKVBlockKeys(
@@ -498,7 +498,7 @@ func TestBlockStoredEvent_OffloadingEmptyTokens(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, gpuBatch, "pod-a", "test-model")
+	pool.processEventBatch(ctx, gpuBatch, "pod-a", "test-model", nil)
 
 	canonicalKeys, err := tp.TokensToKVBlockKeys(
 		kvblock.EmptyBlockHash, tokens, "test-model", nil)
@@ -524,7 +524,7 @@ func TestBlockStoredEvent_OffloadingEmptyTokens(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, cpuBatch, "pod-a", "test-model")
+	pool.processEventBatch(ctx, cpuBatch, "pod-a", "test-model", nil)
 
 	// Verify both GPU and CPU entries now exist for each canonical key.
 	for _, ck := range canonicalKeys {
@@ -560,7 +560,7 @@ func TestBlockStoredEvent_OffloadingUnknownEngineKeys(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		pool.processEventBatch(ctx, cpuBatch, "pod-x", "test-model")
+		pool.processEventBatch(ctx, cpuBatch, "pod-x", "test-model", nil)
 	})
 }
 
@@ -583,7 +583,7 @@ func TestBlockStoredEvent_EvictionOrderGPUThenCPU(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, gpuBatch, "pod-a", "test-model")
+	pool.processEventBatch(ctx, gpuBatch, "pod-a", "test-model", nil)
 
 	canonicalKeys, err := tp.TokensToKVBlockKeys(
 		kvblock.EmptyBlockHash, tokens, "test-model", nil)
@@ -601,7 +601,7 @@ func TestBlockStoredEvent_EvictionOrderGPUThenCPU(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, cpuBatch, "pod-a", "test-model")
+	pool.processEventBatch(ctx, cpuBatch, "pod-a", "test-model", nil)
 
 	// Verify both tiers present.
 	for _, ck := range canonicalKeys {
@@ -618,7 +618,7 @@ func TestBlockStoredEvent_EvictionOrderGPUThenCPU(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, gpuEvict, "pod-a", "test-model")
+	pool.processEventBatch(ctx, gpuEvict, "pod-a", "test-model", nil)
 
 	// CPU entries must survive, engine→request mapping must be preserved.
 	for _, ck := range canonicalKeys {
@@ -640,7 +640,7 @@ func TestBlockStoredEvent_EvictionOrderGPUThenCPU(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, cpuEvict, "pod-a", "test-model")
+	pool.processEventBatch(ctx, cpuEvict, "pod-a", "test-model", nil)
 
 	// Everything should be fully cleaned up.
 	for _, ck := range canonicalKeys {
@@ -779,7 +779,7 @@ func TestCanonicalWritePath_PartialBlockDrop(t *testing.T) {
 			},
 		},
 	}
-	pool.processEventBatch(ctx, batch, "pod-partial", "test-model")
+	pool.processEventBatch(ctx, batch, "pod-partial", "test-model", nil)
 
 	// Verify nothing was added to the index
 	result, err := idx.Lookup(ctx, []kvblock.BlockHash{kvblock.BlockHash(1)}, nil)

--- a/tests/e2e/uds_tokenizer/uds_e2e_mm_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_mm_test.go
@@ -294,7 +294,7 @@ func (s *UDSTokenizerSuite) TestMM_IndexLookupRoundTrip() {
 	// Add to index.
 	podID := "mm-test-pod"
 	err = s.kvBlockIndex.Add(s.T().Context(), engineKeys, requestKeys,
-		[]kvblock.PodEntry{{PodIdentifier: podID, DeviceTier: "GPU"}})
+		[]kvblock.PodEntry{{PodIdentifier: podID, DeviceTier: "GPU", DataParallelRank: kvblock.NoDataParallelRank}})
 	s.Require().NoError(err)
 
 	// Look up using the same request keys — should find the pod.

--- a/tests/e2e/uds_tokenizer/uds_e2e_mm_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_mm_test.go
@@ -568,8 +568,8 @@ func (s *UDSTokenizerSuite) TestGoldenMM_Scoring() {
 	s.Require().Contains(pods, s.Pod1IP, "expected pod in scores")
 
 	expectedScore := float64(len(requestKeys))
-	s.Require().Equal(expectedScore, pods[s.Pod1IP],
+	s.Require().Equal(expectedScore, pods[nonDPKey(s.Pod1IP)],
 		"score should equal number of matching block keys")
 	s.T().Logf("Golden MM scoring: prompt=%q, blocks=%d, score=%.0f",
-		goldenMMPrompt, len(requestKeys), pods[s.Pod1IP])
+		goldenMMPrompt, len(requestKeys), pods[nonDPKey(s.Pod1IP)])
 }

--- a/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
@@ -179,8 +179,9 @@ func (s *UDSTokenizerSuite) addEntriesToIndex(
 
 	err := s.kvBlockIndex.Add(s.T().Context(), engineKeys, requestKeys, utils.SliceMap(podList, func(pod string) kvblock.PodEntry {
 		return kvblock.PodEntry{
-			PodIdentifier: pod,
-			DeviceTier:    "gpu",
+			PodIdentifier:    pod,
+			DeviceTier:       "gpu",
+			DataParallelRank: kvblock.NoDataParallelRank,
 		}
 	}))
 	s.Require().NoError(err)

--- a/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
@@ -152,6 +152,13 @@ func (s *UDSTokenizerSuite) TearDownSuite() {
 	}
 }
 
+// nonDPKey builds the score-map key the scorer produces for a non-DP pod.
+// The scorer keys results by kvblock.PodEntry carrying only PodIdentifier and
+// DataParallelRank (NoDataParallelRank for non-DP pods).
+func nonDPKey(pod string) kvblock.PodEntry {
+	return kvblock.PodEntry{PodIdentifier: pod, DataParallelRank: kvblock.NoDataParallelRank}
+}
+
 // promptToEngineAndRequestKeys tokenizes a prompt and returns its corresponding KV block keys.
 //
 //nolint:nonamedreturns // named returns for readability

--- a/tests/e2e/uds_tokenizer/uds_e2e_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_test.go
@@ -448,9 +448,9 @@ func (s *UDSTokenizerSuite) TestGoldenScoring() {
 	s.Require().Contains(pods, s.Pod1IP, "expected pod in scores")
 
 	expectedScore := float64(len(requestKeys))
-	s.Require().Equal(expectedScore, pods[s.Pod1IP],
+	s.Require().Equal(expectedScore, pods[nonDPKey(s.Pod1IP)],
 		"score should equal number of matching block keys")
-	s.T().Logf("Golden scoring: prompt=%q, blocks=%d, score=%.0f", goldenPrompt, len(requestKeys), pods[s.Pod1IP])
+	s.T().Logf("Golden scoring: prompt=%q, blocks=%d, score=%.0f", goldenPrompt, len(requestKeys), pods[nonDPKey(s.Pod1IP)])
 }
 
 // ---------------------------------------------------------------------------
@@ -474,7 +474,7 @@ func (s *UDSTokenizerSuite) TestCacheHit() {
 	s.Require().NoError(err)
 	s.T().Logf("Received pod scores: %+v", pods)
 	s.Len(pods, len(fakePodList), "expected pod scores length to match candidate pods")
-	s.Greater(pods[s.Pod1IP], 1.0, "expected positive pod score")
+	s.Greater(pods[nonDPKey(s.Pod1IP)], 1.0, "expected positive pod score")
 }
 
 // TestCacheMiss queries scores for a prompt that has no index entries
@@ -514,7 +514,7 @@ func (s *UDSTokenizerSuite) TestPrefixReduction() {
 	// Mid-length prompt should match.
 	pods, err = s.indexer.GetPodScores(s.T().Context(), nil, midPrompt, defaultModelName, fakePodList)
 	s.Require().NoError(err)
-	s.Greater(int(pods[s.Pod1IP]), 0, "mid-prompt should have scored > 0")
+	s.Greater(int(pods[nonDPKey(s.Pod1IP)]), 0, "mid-prompt should have scored > 0")
 	s.T().Logf("Mid prompt scores: %+v", pods)
 
 	// Short prompt should match.
@@ -527,7 +527,7 @@ func (s *UDSTokenizerSuite) TestPrefixReduction() {
 	shortTokens, _, err := s.tokenizer.Render(shortPrompt)
 	s.Require().NoError(err)
 	_, shortRequestKeys := s.promptToEngineAndRequestKeys(shortTokens)
-	s.Equal(int(pods[s.Pod1IP]), len(shortRequestKeys),
+	s.Equal(int(pods[nonDPKey(s.Pod1IP)]), len(shortRequestKeys),
 		"all short-prompt block keys should have been indexed")
 }
 
@@ -564,8 +564,8 @@ func (s *UDSTokenizerSuite) TestChatCompletionsFlow() {
 	pods, err = s.indexer.GetPodScores(s.T().Context(), renderReq, "", defaultModelName, fakePodList)
 	s.Require().NoError(err)
 	s.Len(pods, 1, "expected one pod score after indexing")
-	s.Greater(pods[s.Pod1IP], float64(0), "expected positive pod score")
-	s.T().Logf("Chat completions flow score: %v", pods[s.Pod1IP])
+	s.Greater(pods[nonDPKey(s.Pod1IP)], float64(0), "expected positive pod score")
+	s.T().Logf("Chat completions flow score: %v", pods[nonDPKey(s.Pod1IP)])
 }
 
 // ---------------------------------------------------------------------------
@@ -591,7 +591,7 @@ func (s *UDSTokenizerSuite) TestScoreTokensCacheHit() {
 	s.Require().NoError(err)
 	s.T().Logf("ScoreTokens scores: %+v", pods)
 	s.Len(pods, len(fakePodList), "expected pod scores length to match candidate pods")
-	s.Greater(pods[s.Pod1IP], 1.0, "expected positive pod score")
+	s.Greater(pods[nonDPKey(s.Pod1IP)], 1.0, "expected positive pod score")
 }
 
 // TestScoreTokensCacheMiss calls ScoreTokens for tokens
@@ -661,6 +661,6 @@ func (s *UDSTokenizerSuite) TestScoreTokensPrefixReduction() {
 	s.T().Logf("Short prefix scores: %+v", pods)
 
 	_, shortRequestKeys := s.promptToEngineAndRequestKeys(shortTokens)
-	s.Equal(int(pods[s.Pod1IP]), len(shortRequestKeys),
+	s.Equal(int(pods[nonDPKey(s.Pod1IP)]), len(shortRequestKeys),
 		"all short-prefix block keys should have been indexed")
 }

--- a/tests/profiling/kv_cache_index/index_benchmark_test.go
+++ b/tests/profiling/kv_cache_index/index_benchmark_test.go
@@ -97,7 +97,7 @@ func setupMiniredis(b *testing.B) (*miniredis.Miniredis, func()) {
 func benchmarkAdd(b *testing.B, indexType string) {
 	b.Helper()
 	ctx := context.Background()
-	podEntries := []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}}
+	podEntries := []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}}
 	keys := generateWorkloadKeys(benchNumKeys)
 
 	var redisAddr string
@@ -134,7 +134,7 @@ func benchmarkAdd(b *testing.B, indexType string) {
 func benchmarkLookup(b *testing.B, indexType string) {
 	b.Helper()
 	ctx := context.Background()
-	podEntries := []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}}
+	podEntries := []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu", DataParallelRank: kvblock.NoDataParallelRank}}
 
 	// Intentionally use an empty podIdentifierSet to return all pods during lookup,
 	// as documented in the Index interface.


### PR DESCRIPTION
### Summary

- Propagate DataParallelRank from EventBatch through the KV event processing pipeline into PodEntry, enabling the index and scorer to distinguish KV blocks cached by different data-parallel ranks on the same pod.
- Add DataParallelRank int field to PodEntry with sentinel value -1 (NoDataParallelRank) for backward compatibility with non-DP deployments.
- Update LongestPrefixScorer to produce DP-aware scoring keys ("pod-1@dp0") so different ranks on the same pod receive independent scores.
- Add optional int32 data_parallel_rank field to the PodScore proto message and update the gRPC server to populate it.

Fixes: #357 

Follow up PR: https://github.com/llm-d/llm-d-inference-scheduler/pull/750