### PR TITLE
Add SHA256-CBOR hashing algorithm for token processor with extra keys…

### DIFF
--- a/pkg/kvcache/indexer_test.go
+++ b/pkg/kvcache/indexer_test.go
@@ -46,6 +46,13 @@ func (m *mockTokenProcessor) TokensToKVBlockKeys(
 	return m.blockKeys, nil
 }
 
+func (m *mockTokenProcessor) TokensToKVBlockKeysWithDigests(
+	_ kvblock.BlockHash, tokens []uint32, _ string, _ []*kvblock.BlockExtraFeatures,
+) ([]kvblock.BlockHash, [][]byte, error) {
+	m.receivedTokens = tokens
+	return m.blockKeys, nil, nil
+}
+
 func (m *mockTokenProcessor) BlockSize() int {
 	return 16
 }

--- a/pkg/kvcache/kvblock/extra_keys.go
+++ b/pkg/kvcache/kvblock/extra_keys.go
@@ -29,8 +29,73 @@ type MMHash struct {
 
 // BlockExtraFeatures holds per-block extra data that taints the block hash.
 // A nil *BlockExtraFeatures means pure text (no taint).
+//
+// The fields below mirror the per-block extras vLLM concatenates inside
+// generate_block_hash_extra_keys, in the same order that vLLM hashes them:
+//
+//	extra_keys = [LoraName?] + [each MMHashes[i].Hash] + [CacheSalt?] + [PromptEmbedsHash?]
+//
+// Empty/zero fields are simply omitted (matching vLLM's filtering).
+//
+// RawExtras, when non-nil, takes precedence over the structured fields. Use it
+// when the extras list arrived from the wire (e.g. via ParseRawExtraKeys) and
+// should be passed through verbatim without further interpretation.
 type BlockExtraFeatures struct {
+	// RawExtras is the per-block extras list as received from vLLM
+	// (BlockStored.extra_keys[i]). Each element is one of: string, []byte,
+	// int. When non-nil, it is used as-is; the structured fields below are
+	// ignored. A non-nil empty slice is treated the same as nil (no extras).
+	RawExtras []any
+
+	// LoraName, if non-empty, becomes the first element of the flat extras
+	// list. vLLM emits lora_request.lora_name (a string) here.
+	LoraName string
+
+	// MMHashes are multi-modal item identifiers. Each MMHash.Hash becomes an
+	// element of the flat extras list, in the order given.
 	MMHashes []MMHash
+
+	// CacheSalt, if non-empty, is appended after MM hashes. vLLM only sets
+	// this on the first block (block 0) of a request.
+	CacheSalt string
+
+	// PromptEmbedsHash, if non-empty, is appended last as a CBOR byte string.
+	// vLLM emits hashlib.sha256(tensor_data(...)).digest() here.
+	PromptEmbedsHash []byte
+}
+
+// CborExtras returns the value to use as the third element of the
+// (parent, tokens, extras) CBOR triple — a flat []any matching vLLM's per-block
+// extras tuple, or nil for "no extras" (CBOR null).
+//
+// Receiver may be nil for convenience.
+func (ef *BlockExtraFeatures) CborExtras() any {
+	if ef == nil {
+		return nil
+	}
+	if ef.RawExtras != nil {
+		if len(ef.RawExtras) == 0 {
+			return nil
+		}
+		return ef.RawExtras
+	}
+	var out []any
+	if ef.LoraName != "" {
+		out = append(out, ef.LoraName)
+	}
+	for _, mm := range ef.MMHashes {
+		out = append(out, mm.Hash)
+	}
+	if ef.CacheSalt != "" {
+		out = append(out, ef.CacheSalt)
+	}
+	if len(ef.PromptEmbedsHash) > 0 {
+		out = append(out, ef.PromptEmbedsHash)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // PlaceholderRange describes a contiguous range of placeholder tokens for one
@@ -41,9 +106,11 @@ type PlaceholderRange struct {
 }
 
 // ParseRawExtraKeys converts the raw [][]any from BlockStoredEvent.ExtraKeys
-// into typed []*BlockExtraFeatures. Each inner []any element is either:
-//   - a bare string identifier (vLLM v0.18.0+: mm_feature.identifier), or
-//   - a 2-element [string, int] tuple (legacy format, offset is ignored).
+// into typed []*BlockExtraFeatures. Each inner []any is preserved as-is in
+// RawExtras for verbatim re-hashing under vLLM's sha256_cbor scheme; in
+// addition, string entries are mirrored into MMHashes for legacy callers
+// (e.g. heterogeneous-block-size realignment) that consume the structured
+// view.
 //
 // nil inner slices produce nil entries. Returns nil if raw is nil.
 func ParseRawExtraKeys(raw [][]any) ([]*BlockExtraFeatures, error) {
@@ -53,32 +120,27 @@ func ParseRawExtraKeys(raw [][]any) ([]*BlockExtraFeatures, error) {
 
 	result := make([]*BlockExtraFeatures, len(raw))
 	for blockIdx, blockKeys := range raw {
-		if blockKeys == nil {
+		if len(blockKeys) == 0 {
 			continue
 		}
 
-		features := &BlockExtraFeatures{}
+		features := &BlockExtraFeatures{
+			RawExtras: blockKeys,
+		}
 		for _, entry := range blockKeys {
 			switch v := entry.(type) {
 			case string:
-				// vLLM v0.18.0+: bare identifier string per MM item.
 				features.MMHashes = append(features.MMHashes, MMHash{Hash: v})
 			case []any:
-				// Legacy format: [hash, offset] tuple — extract hash, ignore offset.
 				if len(v) >= 1 {
 					if hash, ok := v[0].(string); ok {
 						features.MMHashes = append(features.MMHashes, MMHash{Hash: hash})
 					}
 				}
-			default:
-				// Skip unknown entry types (e.g. LoRA, cache salt).
-				continue
 			}
 		}
 
-		if len(features.MMHashes) > 0 {
-			result[blockIdx] = features
-		}
+		result[blockIdx] = features
 	}
 
 	return result, nil

--- a/pkg/kvcache/kvblock/token_processor.go
+++ b/pkg/kvcache/kvblock/token_processor.go
@@ -172,10 +172,10 @@ func (db *chunkedTokenDatabase) TokensToKVBlockKeys(
 	extraFeatures []*BlockExtraFeatures,
 ) ([]BlockHash, error) {
 	switch db.HashAlgorithm {
-	case HashAlgorithmFNV64a:
-		return db.tokensToKVBlockKeysFNV(parentKey, tokens, modelName, extraFeatures)
-	default: // HashAlgorithmSHA256CBOR and any unrecognised value
+	case HashAlgorithmSHA256CBOR:
 		return db.tokensToKVBlockKeysSHA256(parentKey, tokens, extraFeatures)
+	default: // tokensToKVBlockKeysFNV and any unrecognised value
+		return db.tokensToKVBlockKeysFNV(parentKey, tokens, modelName, extraFeatures)
 	}
 }
 

--- a/pkg/kvcache/kvblock/token_processor.go
+++ b/pkg/kvcache/kvblock/token_processor.go
@@ -18,18 +18,35 @@ package kvblock
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"hash/fnv"
 
 	"github.com/fxamacker/cbor/v2"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/utils"
 )
 
-// defaultBlockSize is the default number of tokens per block.
-// 16 is the default value used by vLLM.
-const defaultBlockSize = 16
+// HashAlgorithm selects the hashing algorithm used by TokensToKVBlockKeys.
+type HashAlgorithm string
+
+const (
+	// HashAlgorithmSHA256CBOR uses SHA256-CBOR hashing, matching vLLM's engine-key
+	// computation.
+	HashAlgorithmSHA256CBOR HashAlgorithm = "sha256_cbor"
+
+	// HashAlgorithmFNV64a uses FNV-64a hashing over CBOR-encoded payloads.
+	// This is the default algorithm.
+	HashAlgorithmFNV64a HashAlgorithm = "fnv64a_cbor"
+)
+
+const (
+	// defaultBlockSize is the default number of tokens per block (vLLM default).
+	defaultBlockSize = 16
+)
 
 // TokenProcessorConfig holds the configuration for the token processor.
 type TokenProcessorConfig struct {
@@ -37,15 +54,24 @@ type TokenProcessorConfig struct {
 	//
 	// Deprecated: Use BlockSizeTokens instead.
 	BlockSize int `json:"blockSize,omitempty"`
+
 	// BlockSizeTokens is the number of tokens per block.
-	// A value of zero is treated as "not set" and resolved to the default (16) by NewChunkedTokenDatabase.
+	// A value of zero is treated as "not set" and resolved to the default (16).
+	// This applies to both FNV64a and SHA256-CBOR algorithms.
 	BlockSizeTokens int `json:"blockSizeTokens"`
-	// HashSeed is used to prefix initial hash chunks, similarly to vLLM's NONE_HASH.
-	// This should be aligned with vLLM's `PYTHONHASHSEED` environment variable.
+
+	// HashSeed is used to prefix initial hash chunks.
+	// - For FNV64a: used directly as the initial hash seed
+	// - For SHA256-CBOR: aligns with vLLM's PYTHONHASHSEED environment variable for NONE_HASH
 	// The system's deployer is responsible for aligning the vLLM deployments
 	// with the same seed value.
 	HashSeed string `json:"hashSeed"`
-	initHash uint64 // cache once
+
+	// HashAlgorithm selects the hashing algorithm.
+	// Valid values: "fnv64a_cbor" (default), "sha256_cbor".
+	HashAlgorithm HashAlgorithm `json:"hashAlgorithm,omitempty"`
+
+	initHash uint64 // cache once for FNV
 }
 
 // DefaultTokenProcessorConfig returns the default configuration for the token processor.
@@ -53,6 +79,7 @@ func DefaultTokenProcessorConfig() *TokenProcessorConfig {
 	return &TokenProcessorConfig{
 		BlockSizeTokens: defaultBlockSize,
 		HashSeed:        "",
+		HashAlgorithm:   HashAlgorithmFNV64a,
 	}
 }
 
@@ -92,6 +119,11 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, erro
 		cfg = *config // local copy — caller's struct is never mutated
 	}
 
+	// Default HashAlgorithm to FNV64a.
+	if cfg.HashAlgorithm == "" {
+		cfg.HashAlgorithm = HashAlgorithmFNV64a
+	}
+
 	// Apply defaults for omitted fields so partial configs (e.g. only hashSeed set) work correctly.
 	if cfg.BlockSizeTokens == 0 && cfg.BlockSize == 0 {
 		cfg.BlockSizeTokens = defaultBlockSize
@@ -111,7 +143,8 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, erro
 		return nil, fmt.Errorf("blockSizeTokens must be greater than 0, got %d", invalidBlockSize)
 	}
 
-	if cfg.initHash == 0 {
+	// Compute and cache FNV initHash only if using FNV algorithm.
+	if cfg.HashAlgorithm == HashAlgorithmFNV64a && cfg.initHash == 0 {
 		h := fnv.New64a()
 		_, _ = h.Write([]byte(cfg.HashSeed))
 		cfg.initHash = h.Sum64()
@@ -128,76 +161,67 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, erro
 	}, nil
 }
 
-// getInitHash returns the initial hash for the given model name.
-func (db *chunkedTokenDatabase) getInitHash(modelName string) uint64 {
-	return db.hash(db.initHash, nil, modelName)
-}
-
-// hash computes the uint64 FNV-64a hash of the given parent, tokens,
-// and extra keys.
-//
-// The hash is computed using FNV-64a over the CBOR canonical encoding of
-// [parent, tokens, extra], ensuring deterministic results across runs and
-// compatibility with vLLM's prefix caching algorithm.
-//
-// The extra parameter enables cache differentiation for LoRA adapters and
-// multi-modal content. Supported types: nil, int, string, map[string]interface{}.
-// Must be CBOR-serializable.
-func (db *chunkedTokenDatabase) hash(parent uint64, tokens []uint32, extra interface{}) uint64 {
-	payload := []interface{}{parent, tokens, extra}
-
-	b, err := db.encoder.Marshal(payload)
-	if err != nil {
-		log.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
-		return 0
-	}
-
-	h := fnv.New64a()
-	_, _ = h.Write(b)
-	return h.Sum64()
-}
-
-// prefixHashes returns a slice of uint64 hashes.
-// extraFeatures must be the same length as tokenChunks (callers guarantee this).
-func (db *chunkedTokenDatabase) prefixHashes(
-	parentHash uint64, tokenChunks [][]uint32, extraFeatures []*BlockExtraFeatures,
-) []uint64 {
-	prefix := parentHash
-	hashes := make([]uint64, len(tokenChunks))
-	for i, chunk := range tokenChunks {
-		var extra interface{}
-		if extraFeatures[i] != nil {
-			extra = extraFeatures[i].MMHashes
-		}
-		prefix = db.hash(prefix, chunk, extra)
-		hashes[i] = prefix
-	}
-	return hashes
-}
-
-// BlockSize returns the number of tokens per block.
+// BlockSize returns the configured number of tokens per block.
 func (db *chunkedTokenDatabase) BlockSize() int {
 	return db.BlockSizeTokens
 }
 
-// chunkTokens splits the input slice of tokens into chunks of size blockSize.
-func (db *chunkedTokenDatabase) chunkTokens(tokens []uint32) [][]uint32 {
-	bs := db.BlockSizeTokens
-	var chunks [][]uint32
-	for i := 0; i < len(tokens); i += bs {
-		end := i + bs
-		if end > len(tokens) {
-			break // no partial blocks
-		}
-
-		chunks = append(chunks, tokens[i:end])
+// TokensToKVBlockKeys converts tokens to block keys using the configured algorithm.
+func (db *chunkedTokenDatabase) TokensToKVBlockKeys(
+	parentKey BlockHash, tokens []uint32, modelName string,
+	extraFeatures []*BlockExtraFeatures,
+) ([]BlockHash, error) {
+	switch db.HashAlgorithm {
+	case HashAlgorithmFNV64a:
+		return db.tokensToKVBlockKeysFNV(parentKey, tokens, modelName, extraFeatures)
+	default: // HashAlgorithmSHA256CBOR and any unrecognised value
+		return db.tokensToKVBlockKeysSHA256(parentKey, tokens, extraFeatures)
 	}
-
-	return chunks
 }
 
-// TokensToKVBlockKeys converts tokens into kv_block.Keys.
-func (db *chunkedTokenDatabase) TokensToKVBlockKeys(
+// --- SHA256-CBOR path ---
+
+// tokensToKVBlockKeysSHA256 implements the SHA256-CBOR hashing path, matching
+// vLLM's engine-key computation with full support for extra features (LoRA,
+// multimodal hashes, cache salt, prompt embeds). modelName is not included
+// in the hash (vLLM sha256_cbor behaviour).
+func (db *chunkedTokenDatabase) tokensToKVBlockKeysSHA256(
+	parentKey BlockHash, tokens []uint32, extraFeatures []*BlockExtraFeatures,
+) ([]BlockHash, error) {
+	if parentKey != EmptyBlockHash {
+		klog.FromContext(context.Background()).Error(
+			fmt.Errorf("non-empty parentKey unsupported for sha256_cbor"),
+			"TokensToKVBlockKeys: parentKey must be EmptyBlockHash for sha256_cbor",
+			"parentKey", parentKey,
+		)
+		return nil, nil
+	}
+
+	chunks := chunkTokensSHA256(tokens, db.BlockSizeTokens)
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+
+	// Validate or initialize extraFeatures to match chunk count
+	if extraFeatures == nil {
+		extraFeatures = make([]*BlockExtraFeatures, len(chunks))
+	} else if len(extraFeatures) != len(chunks) {
+		return nil, fmt.Errorf("extraFeatures length %d does not match token chunk count %d (blockSizeTokens=%d, tokens=%d)",
+			len(extraFeatures), len(chunks), db.BlockSizeTokens, len(tokens))
+	}
+
+	initDigest := getInitHashSHA256(db.HashSeed)
+	hashes := prefixHashesSHA256(initDigest, chunks, extraFeatures)
+
+	return utils.SliceMap(hashes, func(h []byte) BlockHash {
+		return BlockHash(blockHashToEngineKey(h))
+	}), nil
+}
+
+// --- FNV-64a path ---
+
+// tokensToKVBlockKeysFNV implements the original FNV-64a hashing path.
+func (db *chunkedTokenDatabase) tokensToKVBlockKeysFNV(
 	parentKey BlockHash, tokens []uint32, modelName string,
 	extraFeatures []*BlockExtraFeatures,
 ) ([]BlockHash, error) {
@@ -225,4 +249,130 @@ func (db *chunkedTokenDatabase) TokensToKVBlockKeys(
 	return utils.SliceMap(ph, func(hashVal uint64) BlockHash {
 		return BlockHash(hashVal)
 	}), nil
+}
+
+// getInitHash returns the FNV-64a initial hash for the given model name.
+func (db *chunkedTokenDatabase) getInitHash(modelName string) uint64 {
+	return db.hash(db.initHash, nil, modelName)
+}
+
+// hash computes a FNV-64a hash over the CBOR encoding of [parent, tokens, extra].
+func (db *chunkedTokenDatabase) hash(parent uint64, tokens []uint32, extra interface{}) uint64 {
+	payload := []interface{}{parent, tokens, extra}
+
+	b, err := db.encoder.Marshal(payload)
+	if err != nil {
+		log.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
+		return 0
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write(b)
+	return h.Sum64()
+}
+
+// prefixHashes returns FNV-64a prefix hashes for the given chunks.
+func (db *chunkedTokenDatabase) prefixHashes(
+	parentHash uint64, tokenChunks [][]uint32, extraFeatures []*BlockExtraFeatures,
+) []uint64 {
+	prefix := parentHash
+	hashes := make([]uint64, len(tokenChunks))
+	for i, chunk := range tokenChunks {
+		var extra interface{}
+		if extraFeatures[i] != nil {
+			extra = extraFeatures[i].MMHashes
+		}
+		prefix = db.hash(prefix, chunk, extra)
+		hashes[i] = prefix
+	}
+	return hashes
+}
+
+// chunkTokens splits tokens into chunks of db.BlockSizeTokens (FNV path).
+func (db *chunkedTokenDatabase) chunkTokens(tokens []uint32) [][]uint32 {
+	bs := db.BlockSizeTokens
+	var chunks [][]uint32
+	for i := 0; i < len(tokens); i += bs {
+		end := i + bs
+		if end > len(tokens) {
+			break
+		}
+		chunks = append(chunks, tokens[i:end])
+	}
+	return chunks
+}
+
+// --- SHA256-CBOR helpers (package-level, used by scorer and prefetch handler) ---
+
+var cborEncMode cbor.EncMode // initialized once
+
+func init() {
+	var err error
+	cborEncMode, err = cbor.CanonicalEncOptions().EncMode()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create CBOR encoder: %v", err))
+	}
+}
+
+// getInitHashSHA256 computes the 32-byte seed hash using SHA256-CBOR,
+// matching vLLM's NONE_HASH initialization.
+func getInitHashSHA256(seed string) []byte {
+	b, err := cborEncMode.Marshal(seed)
+	if err != nil {
+		klog.FromContext(context.Background()).Error(err, "failed to marshal seed to CBOR")
+		return nil
+	}
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+// hashSHA256 hashes one block: SHA256(CBOR([parent, tokens, extra])),
+// matching vLLM's prefix-cache hash chain. The extra parameter can be any
+// type (nil, string, []any, etc.) and is serialized as-is by CBOR.
+func hashSHA256(parent []byte, tokens []uint32, extra any) []byte {
+	payload := []any{parent, tokens, extra}
+	b, err := cborEncMode.Marshal(payload)
+	if err != nil {
+		klog.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
+		return nil
+	}
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+// prefixHashesSHA256 chains SHA256-CBOR hashes across token chunks,
+// carrying the full 32-byte digest between blocks. Extras from BlockExtraFeatures
+// are included in each block's hash via the CborExtras() method.
+func prefixHashesSHA256(parentHash []byte, tokenChunks [][]uint32, extraFeatures []*BlockExtraFeatures) [][]byte {
+	prefix := parentHash
+	hashes := make([][]byte, len(tokenChunks))
+	for i, chunk := range tokenChunks {
+		var extra any
+		if extraFeatures[i] != nil {
+			extra = extraFeatures[i].CborExtras()
+		}
+		prefix = hashSHA256(prefix, chunk, extra)
+		hashes[i] = prefix
+	}
+	return hashes
+}
+
+// chunkTokensSHA256 splits tokens into full chunks of exactly blockSize;
+// trailing partial chunks are dropped (matches vLLM behaviour).
+func chunkTokensSHA256(tokens []uint32, blockSize int) [][]uint32 {
+	var chunks [][]uint32
+	for i := 0; i < len(tokens); i += blockSize {
+		end := i + blockSize
+		if end > len(tokens) {
+			break
+		}
+		chunks = append(chunks, tokens[i:end])
+	}
+	return chunks
+}
+
+// blockHashToEngineKey extracts the engine key from a SHA256 digest by taking
+// the last 8 bytes (bytes 24–31), matching vLLM's truncation.
+func blockHashToEngineKey(h []byte) uint64 {
+	return binary.BigEndian.Uint64(h[24:])
 }

--- a/pkg/kvcache/kvblock/token_processor.go
+++ b/pkg/kvcache/kvblock/token_processor.go
@@ -18,18 +18,35 @@ package kvblock
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"hash/fnv"
 
 	"github.com/fxamacker/cbor/v2"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/utils"
 )
 
-// defaultBlockSize is the default number of tokens per block.
-// 16 is the default value used by vLLM.
-const defaultBlockSize = 16
+// HashAlgorithm selects the hashing algorithm used by TokensToKVBlockKeys.
+type HashAlgorithm string
+
+const (
+	// HashAlgorithmSHA256CBOR uses SHA256-CBOR hashing, matching vLLM's engine-key
+	// computation.
+	HashAlgorithmSHA256CBOR HashAlgorithm = "sha256_cbor"
+
+	// HashAlgorithmFNV64a uses FNV-64a hashing over CBOR-encoded payloads.
+	// This is the default algorithm.
+	HashAlgorithmFNV64a HashAlgorithm = "fnv64a_cbor"
+)
+
+const (
+	// defaultBlockSize is the default number of tokens per block (vLLM default).
+	defaultBlockSize = 16
+)
 
 // TokenProcessorConfig holds the configuration for the token processor.
 type TokenProcessorConfig struct {
@@ -37,15 +54,24 @@ type TokenProcessorConfig struct {
 	//
 	// Deprecated: Use BlockSizeTokens instead.
 	BlockSize int `json:"blockSize,omitempty"`
+
 	// BlockSizeTokens is the number of tokens per block.
-	// A value of zero is treated as "not set" and resolved to the default (16) by NewChunkedTokenDatabase.
+	// A value of zero is treated as "not set" and resolved to the default (16).
+	// This applies to both FNV64a and SHA256-CBOR algorithms.
 	BlockSizeTokens int `json:"blockSizeTokens"`
-	// HashSeed is used to prefix initial hash chunks, similarly to vLLM's NONE_HASH.
-	// This should be aligned with vLLM's `PYTHONHASHSEED` environment variable.
+
+	// HashSeed is used to prefix initial hash chunks.
+	// - For FNV64a: used directly as the initial hash seed
+	// - For SHA256-CBOR: aligns with vLLM's PYTHONHASHSEED environment variable for NONE_HASH
 	// The system's deployer is responsible for aligning the vLLM deployments
 	// with the same seed value.
 	HashSeed string `json:"hashSeed"`
-	initHash uint64 // cache once
+
+	// HashAlgorithm selects the hashing algorithm.
+	// Valid values: "fnv64a_cbor" (default), "sha256_cbor".
+	HashAlgorithm HashAlgorithm `json:"hashAlgorithm,omitempty"`
+
+	initHash uint64 // cache once for FNV
 }
 
 // DefaultTokenProcessorConfig returns the default configuration for the token processor.
@@ -53,6 +79,7 @@ func DefaultTokenProcessorConfig() *TokenProcessorConfig {
 	return &TokenProcessorConfig{
 		BlockSizeTokens: defaultBlockSize,
 		HashSeed:        "",
+		HashAlgorithm:   HashAlgorithmFNV64a,
 	}
 }
 
@@ -69,6 +96,17 @@ type TokenProcessor interface {
 		parentKey BlockHash, tokens []uint32, modelName string,
 		extraFeatures []*BlockExtraFeatures,
 	) ([]BlockHash, error)
+
+	// TokensToKVBlockKeysWithDigests is identical to TokensToKVBlockKeys but
+	// also returns the underlying full-width digests alongside the truncated
+	// BlockHash values. For SHA256-CBOR each digest is the 32-byte hash; for
+	// FNV-64a each digest is the 8-byte big-endian encoding of the uint64
+	// hash. Used by the prefetch plugin to build vLLM fs-connector filenames,
+	// which require the full hash bytes (vLLM ≥ v0.10.2 writes 64-hex names).
+	TokensToKVBlockKeysWithDigests(
+		parentKey BlockHash, tokens []uint32, modelName string,
+		extraFeatures []*BlockExtraFeatures,
+	) ([]BlockHash, [][]byte, error)
 
 	// BlockSize returns the number of tokens per block used by this processor.
 	BlockSize() int
@@ -92,6 +130,11 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, erro
 		cfg = *config // local copy — caller's struct is never mutated
 	}
 
+	// Default HashAlgorithm to FNV64a.
+	if cfg.HashAlgorithm == "" {
+		cfg.HashAlgorithm = HashAlgorithmFNV64a
+	}
+
 	// Apply defaults for omitted fields so partial configs (e.g. only hashSeed set) work correctly.
 	if cfg.BlockSizeTokens == 0 && cfg.BlockSize == 0 {
 		cfg.BlockSizeTokens = defaultBlockSize
@@ -111,7 +154,8 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, erro
 		return nil, fmt.Errorf("blockSizeTokens must be greater than 0, got %d", invalidBlockSize)
 	}
 
-	if cfg.initHash == 0 {
+	// Compute and cache FNV initHash only if using FNV algorithm.
+	if cfg.HashAlgorithm == HashAlgorithmFNV64a && cfg.initHash == 0 {
 		h := fnv.New64a()
 		_, _ = h.Write([]byte(cfg.HashSeed))
 		cfg.initHash = h.Sum64()
@@ -128,76 +172,109 @@ func NewChunkedTokenDatabase(config *TokenProcessorConfig) (TokenProcessor, erro
 	}, nil
 }
 
-// getInitHash returns the initial hash for the given model name.
-func (db *chunkedTokenDatabase) getInitHash(modelName string) uint64 {
-	return db.hash(db.initHash, nil, modelName)
-}
-
-// hash computes the uint64 FNV-64a hash of the given parent, tokens,
-// and extra keys.
-//
-// The hash is computed using FNV-64a over the CBOR canonical encoding of
-// [parent, tokens, extra], ensuring deterministic results across runs and
-// compatibility with vLLM's prefix caching algorithm.
-//
-// The extra parameter enables cache differentiation for LoRA adapters and
-// multi-modal content. Supported types: nil, int, string, map[string]interface{}.
-// Must be CBOR-serializable.
-func (db *chunkedTokenDatabase) hash(parent uint64, tokens []uint32, extra interface{}) uint64 {
-	payload := []interface{}{parent, tokens, extra}
-
-	b, err := db.encoder.Marshal(payload)
-	if err != nil {
-		log.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
-		return 0
-	}
-
-	h := fnv.New64a()
-	_, _ = h.Write(b)
-	return h.Sum64()
-}
-
-// prefixHashes returns a slice of uint64 hashes.
-// extraFeatures must be the same length as tokenChunks (callers guarantee this).
-func (db *chunkedTokenDatabase) prefixHashes(
-	parentHash uint64, tokenChunks [][]uint32, extraFeatures []*BlockExtraFeatures,
-) []uint64 {
-	prefix := parentHash
-	hashes := make([]uint64, len(tokenChunks))
-	for i, chunk := range tokenChunks {
-		var extra interface{}
-		if extraFeatures[i] != nil {
-			extra = extraFeatures[i].MMHashes
-		}
-		prefix = db.hash(prefix, chunk, extra)
-		hashes[i] = prefix
-	}
-	return hashes
-}
-
-// BlockSize returns the number of tokens per block.
+// BlockSize returns the configured number of tokens per block.
 func (db *chunkedTokenDatabase) BlockSize() int {
 	return db.BlockSizeTokens
 }
 
-// chunkTokens splits the input slice of tokens into chunks of size blockSize.
-func (db *chunkedTokenDatabase) chunkTokens(tokens []uint32) [][]uint32 {
-	bs := db.BlockSizeTokens
-	var chunks [][]uint32
-	for i := 0; i < len(tokens); i += bs {
-		end := i + bs
-		if end > len(tokens) {
-			break // no partial blocks
-		}
-
-		chunks = append(chunks, tokens[i:end])
+// TokensToKVBlockKeys converts tokens to block keys using the configured algorithm.
+func (db *chunkedTokenDatabase) TokensToKVBlockKeys(
+	parentKey BlockHash, tokens []uint32, modelName string,
+	extraFeatures []*BlockExtraFeatures,
+) ([]BlockHash, error) {
+	switch db.HashAlgorithm {
+	case HashAlgorithmSHA256CBOR:
+		return db.tokensToKVBlockKeysSHA256(parentKey, tokens, extraFeatures)
+	default: // tokensToKVBlockKeysFNV and any unrecognised value
+		return db.tokensToKVBlockKeysFNV(parentKey, tokens, modelName, extraFeatures)
 	}
-
-	return chunks
 }
 
-// TokensToKVBlockKeys converts tokens into kv_block.Keys.
-func (db *chunkedTokenDatabase) TokensToKVBlockKeys(
+// TokensToKVBlockKeysWithDigests returns BlockHash keys plus the underlying
+// full-width hash digests. SHA256-CBOR returns the 32-byte digests as-is; FNV
+// returns the 8-byte big-endian encoding of each uint64 hash. The prefetch
+// plugin uses the digests to build vLLM fs-connector filenames.
+func (db *chunkedTokenDatabase) TokensToKVBlockKeysWithDigests(
+	parentKey BlockHash, tokens []uint32, modelName string,
+	extraFeatures []*BlockExtraFeatures,
+) ([]BlockHash, [][]byte, error) {
+	switch db.HashAlgorithm {
+	case HashAlgorithmSHA256CBOR:
+		digests, err := db.tokensToSHA256Digests(parentKey, tokens, extraFeatures)
+		if err != nil {
+			return nil, nil, err
+		}
+		keys := utils.SliceMap(digests, func(h []byte) BlockHash {
+			return BlockHash(blockHashToEngineKey(h))
+		})
+		return keys, digests, nil
+	default:
+		keys, err := db.tokensToKVBlockKeysFNV(parentKey, tokens, modelName, extraFeatures)
+		if err != nil {
+			return nil, nil, err
+		}
+		digests := make([][]byte, len(keys))
+		for i, k := range keys {
+			buf := make([]byte, 8)
+			binary.BigEndian.PutUint64(buf, uint64(k))
+			digests[i] = buf
+		}
+		return keys, digests, nil
+	}
+}
+
+// --- SHA256-CBOR path ---
+
+// tokensToSHA256Digests computes the chained 32-byte SHA256-CBOR digests for
+// the given tokens, matching vLLM's engine-key computation with full support
+// for extra features (LoRA, multimodal hashes, cache salt, prompt embeds).
+// modelName is not included in the hash (vLLM sha256_cbor behaviour). Returns
+// the raw [][]byte digests; truncation to a uint64 BlockHash is performed by
+// the caller.
+func (db *chunkedTokenDatabase) tokensToSHA256Digests(
+	parentKey BlockHash, tokens []uint32, extraFeatures []*BlockExtraFeatures,
+) ([][]byte, error) {
+	if parentKey != EmptyBlockHash {
+		klog.FromContext(context.Background()).Error(
+			fmt.Errorf("non-empty parentKey unsupported for sha256_cbor"),
+			"TokensToKVBlockKeys: parentKey must be EmptyBlockHash for sha256_cbor",
+			"parentKey", parentKey,
+		)
+		return nil, nil
+	}
+
+	chunks := chunkTokensSHA256(tokens, db.BlockSizeTokens)
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+
+	if extraFeatures == nil {
+		extraFeatures = make([]*BlockExtraFeatures, len(chunks))
+	} else if len(extraFeatures) != len(chunks) {
+		return nil, fmt.Errorf("extraFeatures length %d does not match token chunk count %d (blockSizeTokens=%d, tokens=%d)",
+			len(extraFeatures), len(chunks), db.BlockSizeTokens, len(tokens))
+	}
+
+	initDigest := getInitHashSHA256(db.HashSeed)
+	return prefixHashesSHA256(initDigest, chunks, extraFeatures), nil
+}
+
+func (db *chunkedTokenDatabase) tokensToKVBlockKeysSHA256(
+	parentKey BlockHash, tokens []uint32, extraFeatures []*BlockExtraFeatures,
+) ([]BlockHash, error) {
+	hashes, err := db.tokensToSHA256Digests(parentKey, tokens, extraFeatures)
+	if err != nil {
+		return nil, err
+	}
+	return utils.SliceMap(hashes, func(h []byte) BlockHash {
+		return BlockHash(blockHashToEngineKey(h))
+	}), nil
+}
+
+// --- FNV-64a path ---
+
+// tokensToKVBlockKeysFNV implements the original FNV-64a hashing path.
+func (db *chunkedTokenDatabase) tokensToKVBlockKeysFNV(
 	parentKey BlockHash, tokens []uint32, modelName string,
 	extraFeatures []*BlockExtraFeatures,
 ) ([]BlockHash, error) {
@@ -225,4 +302,130 @@ func (db *chunkedTokenDatabase) TokensToKVBlockKeys(
 	return utils.SliceMap(ph, func(hashVal uint64) BlockHash {
 		return BlockHash(hashVal)
 	}), nil
+}
+
+// getInitHash returns the FNV-64a initial hash for the given model name.
+func (db *chunkedTokenDatabase) getInitHash(modelName string) uint64 {
+	return db.hash(db.initHash, nil, modelName)
+}
+
+// hash computes a FNV-64a hash over the CBOR encoding of [parent, tokens, extra].
+func (db *chunkedTokenDatabase) hash(parent uint64, tokens []uint32, extra interface{}) uint64 {
+	payload := []interface{}{parent, tokens, extra}
+
+	b, err := db.encoder.Marshal(payload)
+	if err != nil {
+		log.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
+		return 0
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write(b)
+	return h.Sum64()
+}
+
+// prefixHashes returns FNV-64a prefix hashes for the given chunks.
+func (db *chunkedTokenDatabase) prefixHashes(
+	parentHash uint64, tokenChunks [][]uint32, extraFeatures []*BlockExtraFeatures,
+) []uint64 {
+	prefix := parentHash
+	hashes := make([]uint64, len(tokenChunks))
+	for i, chunk := range tokenChunks {
+		var extra interface{}
+		if extraFeatures[i] != nil {
+			extra = extraFeatures[i].MMHashes
+		}
+		prefix = db.hash(prefix, chunk, extra)
+		hashes[i] = prefix
+	}
+	return hashes
+}
+
+// chunkTokens splits tokens into chunks of db.BlockSizeTokens (FNV path).
+func (db *chunkedTokenDatabase) chunkTokens(tokens []uint32) [][]uint32 {
+	bs := db.BlockSizeTokens
+	var chunks [][]uint32
+	for i := 0; i < len(tokens); i += bs {
+		end := i + bs
+		if end > len(tokens) {
+			break
+		}
+		chunks = append(chunks, tokens[i:end])
+	}
+	return chunks
+}
+
+// --- SHA256-CBOR helpers (package-level, used by scorer and prefetch handler) ---
+
+var cborEncMode cbor.EncMode // initialized once
+
+func init() {
+	var err error
+	cborEncMode, err = cbor.CanonicalEncOptions().EncMode()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create CBOR encoder: %v", err))
+	}
+}
+
+// getInitHashSHA256 computes the 32-byte seed hash using SHA256-CBOR,
+// matching vLLM's NONE_HASH initialization.
+func getInitHashSHA256(seed string) []byte {
+	b, err := cborEncMode.Marshal(seed)
+	if err != nil {
+		klog.FromContext(context.Background()).Error(err, "failed to marshal seed to CBOR")
+		return nil
+	}
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+// hashSHA256 hashes one block: SHA256(CBOR([parent, tokens, extra])),
+// matching vLLM's prefix-cache hash chain. The extra parameter can be any
+// type (nil, string, []any, etc.) and is serialized as-is by CBOR.
+func hashSHA256(parent []byte, tokens []uint32, extra any) []byte {
+	payload := []any{parent, tokens, extra}
+	b, err := cborEncMode.Marshal(payload)
+	if err != nil {
+		klog.FromContext(context.Background()).Error(err, "failed to marshal payload to CBOR")
+		return nil
+	}
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+// prefixHashesSHA256 chains SHA256-CBOR hashes across token chunks,
+// carrying the full 32-byte digest between blocks. Extras from BlockExtraFeatures
+// are included in each block's hash via the CborExtras() method.
+func prefixHashesSHA256(parentHash []byte, tokenChunks [][]uint32, extraFeatures []*BlockExtraFeatures) [][]byte {
+	prefix := parentHash
+	hashes := make([][]byte, len(tokenChunks))
+	for i, chunk := range tokenChunks {
+		var extra any
+		if extraFeatures[i] != nil {
+			extra = extraFeatures[i].CborExtras()
+		}
+		prefix = hashSHA256(prefix, chunk, extra)
+		hashes[i] = prefix
+	}
+	return hashes
+}
+
+// chunkTokensSHA256 splits tokens into full chunks of exactly blockSize;
+// trailing partial chunks are dropped (matches vLLM behaviour).
+func chunkTokensSHA256(tokens []uint32, blockSize int) [][]uint32 {
+	var chunks [][]uint32
+	for i := 0; i < len(tokens); i += blockSize {
+		end := i + blockSize
+		if end > len(tokens) {
+			break
+		}
+		chunks = append(chunks, tokens[i:end])
+	}
+	return chunks
+}
+
+// blockHashToEngineKey extracts the engine key from a SHA256 digest by taking
+// the last 8 bytes (bytes 24–31), matching vLLM's truncation.
+func blockHashToEngineKey(h []byte) uint64 {
+	return binary.BigEndian.Uint64(h[24:])
 }

--- a/pkg/kvcache/kvblock/token_processor_sha256_extras_test.go
+++ b/pkg/kvcache/kvblock/token_processor_sha256_extras_test.go
@@ -1,0 +1,498 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Tests for SHA256-CBOR hashing with extra features support (LoRA, MM, salt, embeds).
+
+package kvblock_test
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+)
+
+// ---------------------------------------------------------------------------
+// Test Configuration Helpers
+// ---------------------------------------------------------------------------
+
+// sha256ConfigUnified returns a TokenProcessorConfig using the unified fields
+// (HashSeed, BlockSizeTokens) for SHA256-CBOR mode.
+func sha256ConfigUnified(seed string, blockSize int) *kvblock.TokenProcessorConfig {
+	return &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmSHA256CBOR,
+		HashSeed:        seed,
+		BlockSizeTokens: blockSize,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BlockExtraFeatures.CborExtras() Tests
+// ---------------------------------------------------------------------------
+
+func TestBlockExtraFeatures_cborExtras_Nil(t *testing.T) {
+	var ef *kvblock.BlockExtraFeatures
+	result := ef.CborExtras()
+	assert.Nil(t, result, "nil receiver should return nil")
+}
+
+func TestBlockExtraFeatures_cborExtras_EmptyStruct(t *testing.T) {
+	ef := &kvblock.BlockExtraFeatures{}
+	result := ef.CborExtras()
+	assert.Nil(t, result, "empty struct should return nil")
+}
+
+func TestBlockExtraFeatures_cborExtras_RawExtrasTakesPrecedence(t *testing.T) {
+	ef := &kvblock.BlockExtraFeatures{
+		RawExtras: []any{"raw1", "raw2"},
+		LoraName:  "should-be-ignored",
+		MMHashes:  []kvblock.MMHash{{Hash: "should-be-ignored"}},
+	}
+	result := ef.CborExtras()
+	require.NotNil(t, result)
+
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 2)
+	assert.Equal(t, "raw1", arr[0])
+	assert.Equal(t, "raw2", arr[1])
+}
+
+func TestBlockExtraFeatures_cborExtras_EmptyRawExtrasReturnsNil(t *testing.T) {
+	ef := &kvblock.BlockExtraFeatures{
+		RawExtras: []any{},
+	}
+	result := ef.CborExtras()
+	assert.Nil(t, result, "empty RawExtras should return nil")
+}
+
+func TestBlockExtraFeatures_cborExtras_LoraOnly(t *testing.T) {
+	ef := &kvblock.BlockExtraFeatures{
+		LoraName: "my-lora-adapter",
+	}
+	result := ef.CborExtras()
+	require.NotNil(t, result)
+
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 1)
+	assert.Equal(t, "my-lora-adapter", arr[0])
+}
+
+func TestBlockExtraFeatures_cborExtras_MMHashesOnly(t *testing.T) {
+	ef := &kvblock.BlockExtraFeatures{
+		MMHashes: []kvblock.MMHash{
+			{Hash: "mm_hash_1"},
+			{Hash: "mm_hash_2"},
+		},
+	}
+	result := ef.CborExtras()
+	require.NotNil(t, result)
+
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 2)
+	assert.Equal(t, "mm_hash_1", arr[0])
+	assert.Equal(t, "mm_hash_2", arr[1])
+}
+
+func TestBlockExtraFeatures_cborExtras_CacheSaltOnly(t *testing.T) {
+	ef := &kvblock.BlockExtraFeatures{
+		CacheSalt: "debug-session-123",
+	}
+	result := ef.CborExtras()
+	require.NotNil(t, result)
+
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 1)
+	assert.Equal(t, "debug-session-123", arr[0])
+}
+
+func TestBlockExtraFeatures_cborExtras_PromptEmbedsOnly(t *testing.T) {
+	embedsHash := []byte{0x01, 0x02, 0x03, 0x04}
+	ef := &kvblock.BlockExtraFeatures{
+		PromptEmbedsHash: embedsHash,
+	}
+	result := ef.CborExtras()
+	require.NotNil(t, result)
+
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 1)
+	assert.Equal(t, embedsHash, arr[0])
+}
+
+func TestBlockExtraFeatures_cborExtras_CorrectOrdering(t *testing.T) {
+	// vLLM order: [LoRA?, MM..., Salt?, Embeds?]
+	embedsHash := []byte{0xaa, 0xbb}
+	ef := &kvblock.BlockExtraFeatures{
+		LoraName:         "lora-adapter",
+		MMHashes:         []kvblock.MMHash{{Hash: "mm1"}, {Hash: "mm2"}},
+		CacheSalt:        "salt-xyz",
+		PromptEmbedsHash: embedsHash,
+	}
+	result := ef.CborExtras()
+	require.NotNil(t, result)
+
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 5)
+
+	assert.Equal(t, "lora-adapter", arr[0], "LoRA should be first")
+	assert.Equal(t, "mm1", arr[1], "MM hash 1 should be second")
+	assert.Equal(t, "mm2", arr[2], "MM hash 2 should be third")
+	assert.Equal(t, "salt-xyz", arr[3], "Salt should be fourth")
+	assert.Equal(t, embedsHash, arr[4], "Embeds should be last")
+}
+
+// ---------------------------------------------------------------------------
+// SHA256 with Extra Features Integration Tests
+// ---------------------------------------------------------------------------
+
+func TestSHA256_ExtraFeatures_TextOnlyVsWithExtras(t *testing.T) {
+	p := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	tokens := makeTokensSHA256(16) // one block
+
+	// Text-only (nil extras)
+	keysText, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+	require.Len(t, keysText, 1)
+
+	// With LoRA extra
+	extras := []*kvblock.BlockExtraFeatures{
+		{LoraName: "my-lora"},
+	}
+	keysLora, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extras)
+	require.NoError(t, err)
+	require.Len(t, keysLora, 1)
+
+	assert.NotEqual(t, keysText[0], keysLora[0],
+		"text-only and LoRA-tagged blocks must produce different hashes")
+}
+
+func TestSHA256_ExtraFeatures_DifferentLoRAsDifferentHashes(t *testing.T) {
+	p := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	tokens := makeTokensSHA256(16)
+
+	extrasA := []*kvblock.BlockExtraFeatures{{LoraName: "lora-A"}}
+	extrasB := []*kvblock.BlockExtraFeatures{{LoraName: "lora-B"}}
+
+	keysA, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extrasA)
+	require.NoError(t, err)
+	keysB, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extrasB)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, keysA[0], keysB[0],
+		"different LoRA adapters must produce different hashes")
+}
+
+func TestSHA256_ExtraFeatures_DifferentMMHashesDifferentKeys(t *testing.T) {
+	p := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	tokens := makeTokensSHA256(16)
+
+	extrasA := []*kvblock.BlockExtraFeatures{
+		{MMHashes: []kvblock.MMHash{{Hash: "image_A"}}},
+	}
+	extrasB := []*kvblock.BlockExtraFeatures{
+		{MMHashes: []kvblock.MMHash{{Hash: "image_B"}}},
+	}
+
+	keysA, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extrasA)
+	require.NoError(t, err)
+	keysB, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extrasB)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, keysA[0], keysB[0],
+		"different MM hashes must produce different block keys")
+}
+
+func TestSHA256_ExtraFeatures_CacheSaltAffectsHash(t *testing.T) {
+	p := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	tokens := makeTokensSHA256(16)
+
+	extrasNoSalt := []*kvblock.BlockExtraFeatures{{}}
+	extrasWithSalt := []*kvblock.BlockExtraFeatures{{CacheSalt: "session-123"}}
+
+	keysNoSalt, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extrasNoSalt)
+	require.NoError(t, err)
+	keysWithSalt, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extrasWithSalt)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, keysNoSalt[0], keysWithSalt[0],
+		"cache salt must affect block hash")
+}
+
+func TestSHA256_ExtraFeatures_PromptEmbedsAffectHash(t *testing.T) {
+	p := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	tokens := makeTokensSHA256(16)
+
+	embedsA := []byte{0x01, 0x02, 0x03}
+	embedsB := []byte{0x04, 0x05, 0x06}
+
+	extrasA := []*kvblock.BlockExtraFeatures{{PromptEmbedsHash: embedsA}}
+	extrasB := []*kvblock.BlockExtraFeatures{{PromptEmbedsHash: embedsB}}
+
+	keysA, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extrasA)
+	require.NoError(t, err)
+	keysB, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extrasB)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, keysA[0], keysB[0],
+		"different prompt embeds hashes must produce different block keys")
+}
+
+func TestSHA256_ExtraFeatures_MultiBlockWithVaryingExtras(t *testing.T) {
+	p := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	tokens := makeTokensSHA256(48) // 3 blocks
+
+	// Block 0: LoRA + MM + salt
+	// Block 1: LoRA + MM (no salt)
+	// Block 2: LoRA only
+	extras := []*kvblock.BlockExtraFeatures{
+		{
+			LoraName:  "adapter-1",
+			MMHashes:  []kvblock.MMHash{{Hash: "img_abc"}},
+			CacheSalt: "salt-first-block",
+		},
+		{
+			LoraName: "adapter-1",
+			MMHashes: []kvblock.MMHash{{Hash: "img_abc"}},
+		},
+		{
+			LoraName: "adapter-1",
+		},
+	}
+
+	keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extras)
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+
+	// All three blocks should have different hashes due to different extras
+	assert.NotEqual(t, keys[0], keys[1], "block 0 and 1 should differ (salt)")
+	assert.NotEqual(t, keys[1], keys[2], "block 1 and 2 should differ (MM hash)")
+	assert.NotEqual(t, keys[0], keys[2], "block 0 and 2 should differ")
+}
+
+func TestSHA256_ExtraFeatures_RawExtrasPassthrough(t *testing.T) {
+	p := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	tokens := makeTokensSHA256(16)
+
+	// Use RawExtras to pass through exact wire format
+	rawExtras := []any{"lora-name", "mm_hash_1", "salt-value"}
+	extras := []*kvblock.BlockExtraFeatures{
+		{RawExtras: rawExtras},
+	}
+
+	keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extras)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	// Verify it produces a valid hash (non-zero)
+	assert.NotEqual(t, kvblock.EmptyBlockHash, keys[0])
+}
+
+func TestSHA256_ExtraFeatures_MismatchedLengthReturnsError(t *testing.T) {
+	p := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	tokens := makeTokensSHA256(32) // 2 blocks
+
+	// Only 1 extra feature for 2 blocks
+	extras := []*kvblock.BlockExtraFeatures{{LoraName: "lora"}}
+
+	_, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extras)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match token chunk count")
+}
+
+// ---------------------------------------------------------------------------
+// Unified Config Tests (HashSeed + BlockSizeTokens for SHA256)
+// ---------------------------------------------------------------------------
+
+func TestSHA256_UnifiedConfig_HashSeedWorks(t *testing.T) {
+	tokens := makeTokensSHA256(16)
+
+	p1 := newProcessorSHA256(t, sha256ConfigUnified("seed-A", 16))
+	p2 := newProcessorSHA256(t, sha256ConfigUnified("seed-B", 16))
+
+	keys1, err := p1.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+	keys2, err := p2.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, keys1[0], keys2[0],
+		"different HashSeed values must produce different hashes")
+}
+
+func TestSHA256_UnifiedConfig_BlockSizeTokensWorks(t *testing.T) {
+	tokens := makeTokensSHA256(64)
+
+	p16 := newProcessorSHA256(t, sha256ConfigUnified("0", 16))
+	p32 := newProcessorSHA256(t, sha256ConfigUnified("0", 32))
+
+	keys16, err := p16.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+	keys32, err := p32.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	assert.Len(t, keys16, 4, "16-token blocks should produce 4 blocks")
+	assert.Len(t, keys32, 2, "32-token blocks should produce 2 blocks")
+	assert.NotEqual(t, keys16[0], keys32[0],
+		"different block sizes must produce different first block hashes")
+}
+
+func TestSHA256_UnifiedConfig_DefaultsToFNV(t *testing.T) {
+	// Default config should use FNV, not SHA256
+	p := newProcessorSHA256(t, nil)
+	tokens := makeTokensSHA256(16)
+
+	keysFNV, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	// Explicitly SHA256
+	pSHA := newProcessorSHA256(t, sha256ConfigUnified("", 16))
+	keysSHA, err := pSHA.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, keysFNV[0], keysSHA[0],
+		"default (FNV) and explicit SHA256 must produce different hashes")
+}
+
+// ---------------------------------------------------------------------------
+// ParseRawExtraKeys with New Fields
+// ---------------------------------------------------------------------------
+
+func TestParseRawExtraKeys_PreservesRawExtras(t *testing.T) {
+	raw := [][]any{
+		{"lora-name", "mm_hash_1", "salt"},
+		{"lora-name", "mm_hash_2"},
+	}
+
+	result, err := kvblock.ParseRawExtraKeys(raw)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	// RawExtras should be preserved
+	require.NotNil(t, result[0])
+	assert.Equal(t, raw[0], result[0].RawExtras)
+
+	require.NotNil(t, result[1])
+	assert.Equal(t, raw[1], result[1].RawExtras)
+}
+
+func TestParseRawExtraKeys_AlsoPopulatesMMHashes(t *testing.T) {
+	raw := [][]any{
+		{"string_hash_1", "string_hash_2"},
+	}
+
+	result, err := kvblock.ParseRawExtraKeys(raw)
+	require.NoError(t, err)
+	require.NotNil(t, result[0])
+
+	// RawExtras preserved
+	assert.Equal(t, raw[0], result[0].RawExtras)
+
+	// MMHashes also populated for legacy callers
+	require.Len(t, result[0].MMHashes, 2)
+	assert.Equal(t, "string_hash_1", result[0].MMHashes[0].Hash)
+	assert.Equal(t, "string_hash_2", result[0].MMHashes[1].Hash)
+}
+
+func TestParseRawExtraKeys_EmptySliceReturnsNil(t *testing.T) {
+	raw := [][]any{
+		{}, // empty slice
+	}
+
+	result, err := kvblock.ParseRawExtraKeys(raw)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Nil(t, result[0], "empty inner slice should produce nil entry")
+}
+
+// ---------------------------------------------------------------------------
+// Reference Value Tests with Extras
+// ---------------------------------------------------------------------------
+
+func referenceHashSHA256WithExtras(parent []byte, tokens []uint32, extras any) []byte {
+	enc, err := cbor.CanonicalEncOptions().EncMode()
+	if err != nil {
+		panic(err)
+	}
+	payload := []any{parent, tokens, extras}
+	b, err := enc.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+func TestSHA256_ExtraFeatures_MatchesReferenceWithLoRA(t *testing.T) {
+	const seed = "0"
+	const blockSize = 16
+	tokens := makeTokensSHA256(blockSize)
+
+	p := newProcessorSHA256(t, sha256ConfigUnified(seed, blockSize))
+	extras := []*kvblock.BlockExtraFeatures{
+		{LoraName: "test-lora"},
+	}
+
+	keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extras)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	// Compute reference
+	initDigest := referenceInitHashSHA256(seed)
+	extrasArray := []any{"test-lora"}
+	blockDigest := referenceHashSHA256WithExtras(initDigest, tokens, extrasArray)
+	wantKey := kvblock.BlockHash(referenceEngineKey(blockDigest))
+
+	assert.Equal(t, wantKey, keys[0],
+		"SHA256 with LoRA extra must match independent reference computation")
+}
+
+func TestSHA256_ExtraFeatures_MatchesReferenceWithMultipleExtras(t *testing.T) {
+	const seed = "0"
+	const blockSize = 16
+	tokens := makeTokensSHA256(blockSize)
+
+	p := newProcessorSHA256(t, sha256ConfigUnified(seed, blockSize))
+	extras := []*kvblock.BlockExtraFeatures{
+		{
+			LoraName:  "lora-1",
+			MMHashes:  []kvblock.MMHash{{Hash: "mm_a"}, {Hash: "mm_b"}},
+			CacheSalt: "salt-123",
+		},
+	}
+
+	keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extras)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	// Compute reference with same ordering
+	initDigest := referenceInitHashSHA256(seed)
+	extrasArray := []any{"lora-1", "mm_a", "mm_b", "salt-123"}
+	blockDigest := referenceHashSHA256WithExtras(initDigest, tokens, extrasArray)
+	wantKey := kvblock.BlockHash(referenceEngineKey(blockDigest))
+
+	assert.Equal(t, wantKey, keys[0],
+		"SHA256 with multiple extras must match independent reference computation")
+}
+
+// Made with Bob

--- a/pkg/kvcache/kvblock/token_processor_sha256_test.go
+++ b/pkg/kvcache/kvblock/token_processor_sha256_test.go
@@ -1,0 +1,413 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Tests for the SHA256-CBOR hashing path in TokensToKVBlockKeys.
+
+package kvblock_test
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"sync"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+)
+
+// sha256Config returns a TokenProcessorConfig that explicitly selects SHA256-CBOR
+// with the given seed and block size (for tests that need non-default values).
+func sha256Config(seed string, blockSize int) *kvblock.TokenProcessorConfig {
+	return &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmSHA256CBOR,
+		HashSeed:        seed,
+		BlockSizeTokens: blockSize,
+	}
+}
+
+// defaultSHA256Config returns a processor config using the default SHA256 settings
+// (seed "10", block size 64), matching vLLM.
+func defaultSHA256Config() *kvblock.TokenProcessorConfig {
+	return sha256Config("10", 64)
+}
+
+// fnvConfig returns a TokenProcessorConfig that explicitly selects FNV-64a.
+func fnvConfig(seed string, blockSize int) *kvblock.TokenProcessorConfig {
+	return &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmFNV64a,
+		HashSeed:        seed,
+		BlockSizeTokens: blockSize,
+	}
+}
+
+// referenceInitHashSHA256 computes the expected seed digest the same way
+// getInitHashSHA256 does, for independent verification in tests.
+func referenceInitHashSHA256(seed string) []byte {
+	enc, err := cbor.CanonicalEncOptions().EncMode()
+	if err != nil {
+		panic(err)
+	}
+	b, err := enc.Marshal(seed)
+	if err != nil {
+		panic(err)
+	}
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+// referenceHashSHA256 mirrors hashSHA256 for use in reference computations.
+func referenceHashSHA256(parent []byte, tokens []uint32) []byte {
+	enc, err := cbor.CanonicalEncOptions().EncMode()
+	if err != nil {
+		panic(err)
+	}
+	payload := []interface{}{parent, tokens, []interface{}(nil)}
+	b, err := enc.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+func referenceEngineKey(digest []byte) uint64 {
+	return binary.BigEndian.Uint64(digest[24:])
+}
+
+func makeTokensSHA256(n int) []uint32 {
+	t := make([]uint32, n)
+	for i := range t {
+		t[i] = uint32(i + 1)
+	}
+	return t
+}
+
+func newProcessorSHA256(t *testing.T, cfg *kvblock.TokenProcessorConfig) kvblock.TokenProcessor {
+	t.Helper()
+	p, err := kvblock.NewChunkedTokenDatabase(cfg)
+	require.NoError(t, err)
+	return p
+}
+
+// --- Default-algorithm test ---
+
+// TestSHA256_ExplicitAlgorithm verifies that explicitly setting SHA256-CBOR
+// produces consistent results. Note: default algorithm is FNV64a, not SHA256.
+func TestSHA256_ExplicitAlgorithm(t *testing.T) {
+	p1 := newProcessorSHA256(t, &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmSHA256CBOR,
+		HashSeed:        "10",
+		BlockSizeTokens: 64,
+	})
+	p2 := newProcessorSHA256(t, &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmSHA256CBOR,
+		HashSeed:        "10",
+		BlockSizeTokens: 64,
+	})
+
+	tokens := makeTokensSHA256(64)
+	keys1, err := p1.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+	keys2, err := p2.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, keys1, keys2, "explicit SHA256 configs with same settings must produce same result")
+}
+
+// --- Block count tests ---
+
+// TestSHA256_BlockCount verifies chunking uses SHA256BlockSize, not BlockSizeTokens.
+func TestSHA256_BlockCount(t *testing.T) {
+	cases := []struct {
+		name       string
+		numTokens  int
+		blockSize  int
+		wantBlocks int
+	}{
+		{"zero tokens", 0, 64, 0},
+		{"fewer than one block", 63, 64, 0},
+		{"exactly one block", 64, 64, 1},
+		{"one full + partial", 100, 64, 1},
+		{"exactly two blocks", 128, 64, 2},
+		{"three blocks", 192, 64, 3},
+		{"large input", 640, 64, 10},
+		{"custom block size 32", 128, 32, 4},
+		{"custom block size 16", 64, 16, 4},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newProcessorSHA256(t, sha256Config("10", tc.blockSize))
+			tokens := makeTokensSHA256(tc.numTokens)
+			keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+			require.NoError(t, err)
+			assert.Len(t, keys, tc.wantBlocks)
+		})
+	}
+}
+
+// --- Determinism tests ---
+
+func TestSHA256_Deterministic(t *testing.T) {
+	p := newProcessorSHA256(t, defaultSHA256Config())
+	tokens := makeTokensSHA256(192) // 3 blocks
+
+	var first []kvblock.BlockHash
+	for i := 0; i < 5; i++ {
+		keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+		require.NoError(t, err)
+		require.Len(t, keys, 3)
+		if i == 0 {
+			first = keys
+		} else {
+			assert.Equal(t, first, keys, "keys must be identical on repeated calls (iter %d)", i)
+		}
+	}
+}
+
+// TestSHA256_SeedDrivesOutput verifies that different SHA256HashSeed values produce
+// different keys (seed is respected by the SHA256 path).
+func TestSHA256_SeedDrivesOutput(t *testing.T) {
+	tokens := makeTokensSHA256(64)
+
+	seeds := []string{"10", "0", "abc", "different"}
+	seen := map[kvblock.BlockHash]string{}
+	for _, seed := range seeds {
+		p := newProcessorSHA256(t, sha256Config(seed, 64))
+		keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+		if prev, exists := seen[keys[0]]; exists {
+			t.Errorf("seed collision: seeds %q and %q produced the same key", seed, prev)
+		}
+		seen[keys[0]] = seed
+	}
+}
+
+// TestSHA256_BlockSizeDrivesOutput verifies that different SHA256BlockSize values
+// produce different keys (chunking boundary changes the hash chain).
+func TestSHA256_BlockSizeDrivesOutput(t *testing.T) {
+	tokens := makeTokensSHA256(128)
+
+	p32 := newProcessorSHA256(t, sha256Config("10", 32))
+	p64 := newProcessorSHA256(t, sha256Config("10", 64))
+
+	keys32, err := p32.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+	keys64, err := p64.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	require.Len(t, keys32, 4)
+	require.Len(t, keys64, 2)
+	assert.NotEqual(t, keys32[0], keys64[0], "different block sizes must produce different first keys")
+}
+
+// --- Reference value tests ---
+
+// TestSHA256_FirstBlockMatchesReference verifies the first key against an
+// independently computed SHA256-CBOR reference, confirming vLLM compatibility.
+func TestSHA256_FirstBlockMatchesReference(t *testing.T) {
+	const seed = "10"
+	const blockSize = 64
+	tokens := makeTokensSHA256(blockSize)
+
+	p := newProcessorSHA256(t, sha256Config(seed, blockSize))
+	keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	initDigest := referenceInitHashSHA256(seed)
+	blockDigest := referenceHashSHA256(initDigest, tokens)
+	wantKey := kvblock.BlockHash(referenceEngineKey(blockDigest))
+
+	assert.Equal(t, wantKey, keys[0], "first block key must match independent SHA256-CBOR reference")
+}
+
+// TestSHA256_ChainedBlocksMatchReference verifies all blocks in a multi-block
+// sequence match the expected chained SHA256-CBOR computation.
+func TestSHA256_ChainedBlocksMatchReference(t *testing.T) {
+	const seed = "10"
+	const blockSize = 64
+	const numBlocks = 4
+	tokens := makeTokensSHA256(blockSize * numBlocks)
+
+	p := newProcessorSHA256(t, sha256Config(seed, blockSize))
+	keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+	require.Len(t, keys, numBlocks)
+
+	digest := referenceInitHashSHA256(seed)
+	for i := 0; i < numBlocks; i++ {
+		chunk := tokens[i*blockSize : (i+1)*blockSize]
+		digest = referenceHashSHA256(digest, chunk)
+		wantKey := kvblock.BlockHash(referenceEngineKey(digest))
+		assert.Equal(t, wantKey, keys[i], "block %d key mismatch", i)
+	}
+}
+
+// --- Guard and edge-case tests ---
+
+// TestSHA256_NonEmptyParentReturnsNil verifies that a non-empty parentKey is
+// rejected (returns nil, no error).
+func TestSHA256_NonEmptyParentReturnsNil(t *testing.T) {
+	p := newProcessorSHA256(t, defaultSHA256Config())
+	tokens := makeTokensSHA256(64)
+
+	keys, err := p.TokensToKVBlockKeys(kvblock.BlockHash(999), tokens, "model", nil)
+	require.NoError(t, err)
+	assert.Nil(t, keys, "non-empty parentKey must return nil for sha256_cbor path")
+}
+
+func TestSHA256_EmptyAndPartialTokens(t *testing.T) {
+	p := newProcessorSHA256(t, defaultSHA256Config())
+
+	keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, nil, "model", nil)
+	require.NoError(t, err)
+	assert.Empty(t, keys, "nil tokens must produce no keys")
+
+	keys, err = p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, makeTokensSHA256(63), "model", nil)
+	require.NoError(t, err)
+	assert.Empty(t, keys, "partial block (< blockSize tokens) must produce no keys")
+}
+
+// --- Uniqueness and independence tests ---
+
+func TestSHA256_DifferentTokensDifferentKeys(t *testing.T) {
+	p := newProcessorSHA256(t, defaultSHA256Config())
+
+	a := makeTokensSHA256(64)
+	b := makeTokensSHA256(64)
+	b[0] = 99999
+
+	keysA, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, a, "model", nil)
+	require.NoError(t, err)
+	keysB, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, b, "model", nil)
+	require.NoError(t, err)
+
+	require.Len(t, keysA, 1)
+	require.Len(t, keysB, 1)
+	assert.NotEqual(t, keysA[0], keysB[0])
+}
+
+func TestSHA256_KeysAreNotEmptyBlockHash(t *testing.T) {
+	p := newProcessorSHA256(t, defaultSHA256Config())
+	keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, makeTokensSHA256(320), "model", nil)
+	require.NoError(t, err)
+	for i, k := range keys {
+		assert.NotEqual(t, kvblock.EmptyBlockHash, k, "block %d must not be EmptyBlockHash", i)
+	}
+}
+
+// TestSHA256_ModelNameIgnored verifies that modelName has no effect (sha256_cbor
+// does not include modelName in the hash chain).
+func TestSHA256_ModelNameIgnored(t *testing.T) {
+	p := newProcessorSHA256(t, defaultSHA256Config())
+	tokens := makeTokensSHA256(64)
+
+	var first []kvblock.BlockHash
+	for _, m := range []string{"gpt-4", "llama-3", "", "any-model"} {
+		keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, m, nil)
+		require.NoError(t, err)
+		if first == nil {
+			first = keys
+		} else {
+			assert.Equal(t, first, keys, "modelName %q must not affect sha256_cbor keys", m)
+		}
+	}
+}
+
+// TestSHA256_ExtraFeaturesAffectHash verifies that extraFeatures DO affect the hash
+// in SHA256-CBOR mode (this is the key difference from FNV64a mode).
+func TestSHA256_ExtraFeaturesAffectHash(t *testing.T) {
+	p := newProcessorSHA256(t, defaultSHA256Config())
+	tokens := makeTokensSHA256(64)
+
+	keysNil, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	extra := []*kvblock.BlockExtraFeatures{{MMHashes: []kvblock.MMHash{{Hash: "12345"}, {Hash: "67890"}}}}
+	keysExtra, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", extra)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, keysNil, keysExtra, "extraFeatures MUST affect sha256_cbor output (vLLM compatibility)")
+}
+
+// --- Concurrency test ---
+
+func TestSHA256_ConcurrentCalls(t *testing.T) {
+	p := newProcessorSHA256(t, defaultSHA256Config())
+	tokens := makeTokensSHA256(192)
+
+	reference, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	const goroutines = 50
+	results := make(chan []kvblock.BlockHash, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			keys, err := p.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+			if err == nil {
+				results <- keys
+			}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	count := 0
+	for keys := range results {
+		count++
+		assert.Equal(t, reference, keys, "concurrent call produced different keys")
+	}
+	assert.Equal(t, goroutines, count)
+}
+
+// --- BlockSize() method ---
+
+func TestSHA256_BlockSizeMethodReflectsConfig(t *testing.T) {
+	p := newProcessorSHA256(t, &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmSHA256CBOR,
+		HashSeed:        "10",
+		BlockSizeTokens: 32, // BlockSize() returns this
+	})
+	assert.Equal(t, 32, p.BlockSize(), "BlockSize() must return BlockSizeTokens")
+}
+
+// --- Algorithm isolation test ---
+
+// TestAlgorithmIsolation verifies that SHA256 and FNV produce different keys
+// for the same token input (they must not be accidentally interchangeable).
+func TestAlgorithmIsolation(t *testing.T) {
+	tokens := makeTokensSHA256(64)
+
+	pSHA := newProcessorSHA256(t, sha256Config("10", 64))
+	pFNV := newProcessorSHA256(t, fnvConfig("", 64))
+
+	keysSHA, err := pSHA.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+	keysFNV, err := pFNV.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "model", nil)
+	require.NoError(t, err)
+
+	require.Len(t, keysSHA, 1)
+	require.Len(t, keysFNV, 1)
+	assert.NotEqual(t, keysSHA[0], keysFNV[0], "SHA256 and FNV must produce different keys for the same input")
+}

--- a/pkg/kvcache/kvblock/token_processor_test.go
+++ b/pkg/kvcache/kvblock/token_processor_test.go
@@ -137,6 +137,7 @@ func TestTokenProcessorConfig_JSONUnmarshal(t *testing.T) {
 
 func TestTokenProcessorConfig_JSONUnmarshal_EndToEnd(t *testing.T) {
 	// Verify that a config decoded from JSON produces a working processor with the correct block size.
+	// Uses FNV64a so that BlockSizeTokens/BlockSize drive chunking (SHA256 uses its own SHA256BlockSize).
 	tests := []struct {
 		name           string
 		json           string
@@ -145,19 +146,19 @@ func TestTokenProcessorConfig_JSONUnmarshal_EndToEnd(t *testing.T) {
 	}{
 		{
 			name:           "blockSizeTokens drives chunking",
-			json:           `{"blockSizeTokens": 8}`,
+			json:           `{"blockSizeTokens": 8, "hashAlgorithm": "fnv64a_cbor"}`,
 			tokens:         32,
 			wantBlockCount: 4, // 32 / 8
 		},
 		{
 			name:           "legacy blockSize drives chunking via compat path",
-			json:           `{"blockSize": 16}`,
+			json:           `{"blockSize": 16, "hashAlgorithm": "fnv64a_cbor"}`,
 			tokens:         32,
 			wantBlockCount: 2, // 32 / 16
 		},
 		{
 			name:           "partial config with only hashSeed uses default block size of 16",
-			json:           `{"hashSeed": "test"}`,
+			json:           `{"hashSeed": "test", "hashAlgorithm": "fnv64a_cbor"}`,
 			tokens:         32,
 			wantBlockCount: 2, // 32 / 16 (default)
 		},
@@ -245,8 +246,10 @@ func TestTokenProcessorConfig_JSONRoundTrip(t *testing.T) {
 }
 
 func TestBlockSizeTokensPrecedence(t *testing.T) {
-	// Test that BlockSizeTokens takes precedence over BlockSize when both are set
+	// Test that BlockSizeTokens takes precedence over BlockSize when both are set.
+	// Uses FNV64a so that BlockSizeTokens drives chunking.
 	config := &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmFNV64a,
 		BlockSize:       8,  // deprecated field
 		BlockSizeTokens: 16, // new field should take precedence
 		HashSeed:        "test",
@@ -285,9 +288,11 @@ func TestNewChunkedTokenDatabase_DoesNotMutateCallerConfig(t *testing.T) {
 
 func TestBackwardCompatibility_BlockSize(t *testing.T) {
 	// Test that setting only the deprecated BlockSize field still works correctly.
+	// Uses FNV64a so that BlockSize drives chunking.
 	config := &kvblock.TokenProcessorConfig{
-		BlockSize: 8, // deprecated field, BlockSizeTokens not set
-		HashSeed:  "test",
+		HashAlgorithm: kvblock.HashAlgorithmFNV64a,
+		BlockSize:     8, // deprecated field, BlockSizeTokens not set
+		HashSeed:      "test",
 	}
 
 	processor, err := kvblock.NewChunkedTokenDatabase(config)
@@ -309,6 +314,7 @@ func TestBackwardCompatibility_BlockSize(t *testing.T) {
 
 func TestGetInitHash_ConsistentHashesForSameModel(t *testing.T) {
 	config := &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmFNV64a,
 		BlockSizeTokens: 16,
 		HashSeed:        "test-seed",
 	}
@@ -339,6 +345,7 @@ func TestGetInitHash_ConsistentHashesForSameModel(t *testing.T) {
 
 func TestGetInitHash_DifferentHashesForDifferentModels(t *testing.T) {
 	config := &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmFNV64a,
 		BlockSizeTokens: 16,
 		HashSeed:        "test-seed",
 	}
@@ -398,6 +405,7 @@ func TestGetInitHash_DifferentSeedsProduceDifferentHashes(t *testing.T) {
 
 	for _, seed := range seeds {
 		config := &kvblock.TokenProcessorConfig{
+			HashAlgorithm:   kvblock.HashAlgorithmFNV64a,
 			BlockSizeTokens: 16,
 			HashSeed:        seed,
 		}
@@ -425,6 +433,7 @@ func TestGetInitHash_DifferentSeedsProduceDifferentHashes(t *testing.T) {
 
 func TestGetInitHash_ConcurrentAccess(t *testing.T) {
 	config := &kvblock.TokenProcessorConfig{
+		HashAlgorithm:   kvblock.HashAlgorithmFNV64a,
 		BlockSizeTokens: 16,
 		HashSeed:        "test-seed",
 	}
@@ -483,6 +492,7 @@ func TestGetInitHash_Deterministic(t *testing.T) {
 	// Create multiple instances with same config
 	for i := 0; i < 5; i++ {
 		config := &kvblock.TokenProcessorConfig{
+			HashAlgorithm:   kvblock.HashAlgorithmFNV64a,
 			BlockSizeTokens: 16,
 			HashSeed:        seed,
 		}
@@ -782,8 +792,9 @@ func TestHeterogeneousBlockSizeSupport(t *testing.T) {
 	newProcessor := func(t *testing.T, blockSize int) kvblock.TokenProcessor {
 		t.Helper()
 		proc, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
-			BlockSize: blockSize,
-			HashSeed:  "test-seed",
+			HashAlgorithm: kvblock.HashAlgorithmFNV64a,
+			BlockSize:     blockSize,
+			HashSeed:      "test-seed",
 		})
 		require.NoError(t, err)
 		return proc


### PR DESCRIPTION
Add KV-cache file prefetch plugin for inference requests (experimental feature)
Part 1: changes in KV-Cache (current PR)
Part 2: changes in llm-d-router


PR Description:
Introduces a new experimental feature that aims to proactively prefetch KV-cache blocks across different storage tiers before inference requests are processed by the GPU pod. The plugin extends the precise prefix cache scorer with engine key calculation to determine the storage location (file names) of KV-cache blocks that will be needed and arrange for them to be promoted to a closer storage tier to improve inference latency. The current implementation is intended for a shared file system that includes transparent access to a remote storage tier, such as IBM Storage Scale configured to off-load cold data to remote object storage. The prefetch plugin uses a concurrent worker thread pool architecture to efficiently prefetch multiple (configurable) files in parallel from remote storage to the shared file system. In a future version of the plugin this could be extended, for example, to prefetch KV-cache blocks from the file system to CPU memory on the worker node that the request is being routed to.

For this to work correctly, the plugin must be configured to use a hash algorithm for generating engine keys that matches the algorithm used by vLLM when offloading KV-cache blocks to storage. For this purpose, this work adds a configurable hashing algorithm SHA256-CBOR to the token processor as an alternative for vLLM compatibility. The SHA256-CBOR implementation supports extra keys (multimodal features) in block hash computation. In addition, this feature relies on logic derived from the llm-d-fs-connector to generate KV file names, so it currently only works with the llm-d-fs-connector.

Changes include:

New Prefetch Plugin (prefetch_prerequest_experimental.go):
- Implements PreRequest interface for pre-inference file prefetching
- Converts engine keys to filesystem paths using llm-d-fs-connector format
- Manages worker thread pool for concurrent file prefetching (configurable workers)
- Each worker reads configurable number of blocks (BlockSize x BlockCount bytes) from KV-cache files to trigger prefetch of the rest of the file from remote storage.
- Supports configurable prefetch parameters (block size, concurrency, queue size)

Precise Prefix Cache Scorer Enhancement (precise_prefix_cache.go):
- Add GetEngineKeysForRequest() method to extract engine keys from requests
- Support multimodal features in engine key computation

Add SHA256-CBOR hashing algorithm for token processor with extra keys support
- Add configuration to choose hashing function via the field name “hashAlgorithm”: FNV64a default, SHA256-CBOR for vLLM
- Implement SHA256-CBOR hashing matching vLLM engine-key computation
- Extend BlockExtraFeatures for multimodal content support