### PR TITLE
Better tmp file handling (#2)

### DIFF
--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -92,6 +92,7 @@ make image-fs-backend-push IMAGE_TAG_BASE=<your-base-container-registry> FS_BACK
 - `max_write_queued_seconds`: maximum time budget (in seconds) for queued writes before excess writes are dropped (default: `10.0`, set to `0` to disable). The actual write queue depth limit is computed dynamically as `threads_per_gpu * max_write_queued_seconds / avg_write_duration`. For example, with 64 threads and `max_write_queued_seconds=10`: on fast NVMe storage (20ms avg write) the limit is ~32,000 (effectively unlimited), while on slow block storage (2s avg write) the limit is ~320. Dropped writes result in cache misses on future reads, not data loss.
 - `gds_mode`: GPUDirect Storage mode (default: `disabled`). See [GPUDirect Storage (GDS)](./docs/gds.md) for options, requirements, and verification.
 - `backend`: POSIX, OBJ (default: `POSIX`)
+- `o_tmp_file`: Use the `O_TMPFILE` flag for temporary file management on supported file systems; applicable to `llmd_fs_backend` only.
 
 ### Environment variables
 - `STORAGE_LOG_LEVEL`: set the log level for both C++ and Python (`trace`, `debug`, `info`, `warn`, `error`). Default: `info`

--- a/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_gds/gds_file_io.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_gds/gds_file_io.cpp
@@ -37,7 +37,8 @@ thread_local std::string gds_tmp_suffix =
 GdsFileIO::GdsFileIO(const std::vector<std::pair<void*, size_t>>& gpu_buffers,
                      size_t block_size,
                      GdsMode gds_mode,
-                     TensorCopier& tensor_copier)
+                     TensorCopier& tensor_copier,
+                     bool o_tmpfile)
     : m_cufile(CuFileApi::instance()),
       m_gds_initialized(false),
       m_gds_mode(gds_mode),
@@ -49,7 +50,8 @@ GdsFileIO::GdsFileIO(const std::vector<std::pair<void*, size_t>>& gpu_buffers,
       m_use_for_write(gds_mode == GdsMode::WRITE_ONLY ||
                       gds_mode == GdsMode::READ_WRITE ||
                       gds_mode == GdsMode::BB_WRITE_ONLY ||
-                      gds_mode == GdsMode::BB_READ_WRITE) {
+                      gds_mode == GdsMode::BB_READ_WRITE),
+      m_o_tmpfile(o_tmpfile) {
   if (!is_gds_supported()) {
     FS_LOG_INFO("GdsFileIO: GDS not supported, using CPU buffer staging");
     return;
@@ -259,8 +261,8 @@ bool GdsFileIO::write_blocks_to_file(const std::string& file_path,
   std::string tmp_path = file_path + gds_tmp_suffix;
 
   // O_RDWR required by cuFile for internal DMA setup even on write-only paths
-  int fd = open(tmp_path.c_str(), O_RDWR | O_CREAT | O_DIRECT, 0644);
-  if (fd < 0) {
+  TmpFile tmp_file(tmp_path, O_RDWR | O_CREAT | O_DIRECT, 0644);
+  if (!tmp_file) {
     FS_LOG_ERROR("GdsFileIO: Failed to open temporary file "
                  << tmp_path << ": " << std::strerror(errno)
                  << " (errno=" << errno << ")");
@@ -270,15 +272,13 @@ bool GdsFileIO::write_blocks_to_file(const std::string& file_path,
   // Register file descriptor with cuFile driver for DMA setup
   CUfileDescr_t descr;
   memset(&descr, 0, sizeof(CUfileDescr_t));
-  descr.handle.fd = fd;
+  descr.handle.fd = tmp_file.fd();
   descr.type = CU_FILE_HANDLE_TYPE_OPAQUE_FD;
   CUfileHandle_t handle;
   CUfileError_t status = m_cufile.cuFileHandleRegister(&handle, &descr);
   if (status.err != CU_FILE_SUCCESS) {
     FS_LOG_ERROR("GdsFileIO: cuFileHandleRegister failed with error code: "
                  << status.err);
-    close(fd);
-    std::remove(tmp_path.c_str());
     return false;
   }
 
@@ -320,19 +320,16 @@ bool GdsFileIO::write_blocks_to_file(const std::string& file_path,
   }
 
   m_cufile.cuFileHandleDeregister(handle);
-  close(fd);
 
   if (!success) {
-    std::remove(tmp_path.c_str());
     return false;
   }
 
   // Atomically rename temp file to final target path
-  if (std::rename(tmp_path.c_str(), file_path.c_str()) != 0) {
+  if (!tmp_file.rename(file_path)) {
     FS_LOG_ERROR("GdsFileIO: Failed to rename " << tmp_path << " to "
                                                 << file_path << ": "
                                                 << std::strerror(errno));
-    std::remove(tmp_path.c_str());
     return false;
   }
 

--- a/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_gds/gds_file_io.hpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_gds/gds_file_io.hpp
@@ -38,7 +38,8 @@ class GdsFileIO : public StorageHandler {
   GdsFileIO(const std::vector<std::pair<void*, size_t>>& gpu_buffers,
             size_t block_size,
             GdsMode gds_mode,
-            TensorCopier& tensor_copier);
+            TensorCopier& tensor_copier,
+            bool o_tmpfile);
 
   // Destructor: deregisters GPU buffers and releases GDS resources
   ~GdsFileIO();
@@ -84,6 +85,8 @@ class GdsFileIO : public StorageHandler {
   // Computed flags for read/write usage based on mode
   bool m_use_for_read;
   bool m_use_for_write;
+  // Use O_TMPFILE flag for write operations
+  bool m_o_tmpfile;
 
   // Registered GPU buffers (for GDS mode)
   std::unordered_map<void*, size_t> m_registered_buffers;

--- a/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_io/file_io.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_io/file_io.cpp
@@ -43,6 +43,113 @@ thread_local std::vector<char> thread_write_buffer(WRITE_BUFFER_SIZE);
 // Thread-local unique suffix for temporary files
 thread_local std::string tmp_file_suffix =
     "_" + std::to_string(std::random_device{}()) + ".tmp";
+
+// -------------------------------------------------------------------
+// TmpFile Implementation
+// -------------------------------------------------------------------
+TmpFile::TmpFile(const std::string &path, int oflags, int mode) :
+  m_path(path),
+  m_fp(nullptr),
+  m_o_tmpfile(oflags & O_TMPFILE) {
+    auto o_path = m_path;
+    if (m_o_tmpfile) {
+      o_path = m_path.parent_path();
+    }
+
+    int fd = open(o_path.c_str(), oflags, mode);
+    if (fd >= 0) {
+      // Create FILE* wrapper for buffered I/O
+      const char* mode = (oflags & O_ACCMODE) == O_RDONLY ? "rb" : "wb";
+      m_fp = fdopen(fd, mode);
+
+      if (!m_fp) {
+        int saved_errno = errno;  // Save errno before close() potentially overwrites it
+        close(fd);
+        errno = saved_errno;
+      }
+    }
+  }
+
+TmpFile::operator bool() const {
+  return m_fp != nullptr;
+}
+
+ssize_t TmpFile::write_unbuffered(const void* data, size_t size) {
+  if (!m_fp) return -1;
+  int fd = this->fd();
+  const char *p = reinterpret_cast<const char*>(data);
+  size_t total = 0;
+  constexpr size_t CHUNK_SIZE = 4 * 1024 * 1024; // 4MiB
+
+  while (total < size) {
+    size_t remaining = size - total;
+    size_t to_write = (remaining < CHUNK_SIZE) ? remaining : CHUNK_SIZE;
+    ssize_t n = ::write(fd, p + total, to_write);
+    if (n > 0 ) {
+      total += reinterpret_cast<ssize_t>(n);
+      continue;
+    }
+    if (n == -1 && errno == EINTR) {
+      // Special failure where the syscall can be interrupted
+      continue;
+    }
+    // Some other errno that needs to be checked by the caller
+    return -1;
+  }
+  return total;
+}
+
+bool TmpFile::flush() {
+  return m_fp && fflush(m_fp) == 0;
+}
+
+int TmpFile::fd() const {
+  return m_fp ? fileno(m_fp) : -1;
+}
+
+FILE* TmpFile::file_ptr() const {
+  return m_fp;
+}
+
+
+bool TmpFile::rename(const std::string& new_path) {
+  if (!m_fp) return false;
+
+  // Flush any buffered data before rename/link
+  if (!flush()) return false;
+
+  if (m_o_tmpfile) {
+    // For O_TMPFILE, use linkat with AT_EMPTY_PATH to link the fd to the filesystem
+    int file_fd = fd();
+    if (linkat(file_fd, "", AT_FDCWD, new_path.c_str(), AT_EMPTY_PATH) != 0) {
+      return false;
+    }
+  } else {
+    // Standard rename for regular temporary files
+    if (std::rename(m_path.c_str(), new_path.c_str()) != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+TmpFile::~TmpFile() {
+  cleanup();
+}
+
+void TmpFile::cleanup() {
+  if (m_fp) {
+    fclose(m_fp);
+    m_fp = nullptr;
+  }
+
+  if (!m_o_tmpfile && !m_path.empty()) {
+    std::remove(m_path.c_str());
+  }
+  m_path.clear();
+}
+
 // -------------------------------------------------------------------
 // file-IO Functions
 // -------------------------------------------------------------------
@@ -62,38 +169,37 @@ bool FileIO::write_buffer_to_file(const StagingBufferInfo& buf,
   // Write to a temporary file to ensure atomic replace on rename
   // Include tmp_file_suffix so each thread uses a unique temporary file
   std::string tmp_path = target_path + tmp_file_suffix;
-
-  std::ofstream ofs(tmp_path, std::ios::out | std::ios::binary);
-  if (!ofs) {
+  int open_flags = O_RDWR | O_CREAT;
+  if (m_o_tmpfile) {
+    open_flags = O_RDWR | O_TMPFILE;
+  }
+  TmpFile tmp_file(tmp_path, open_flags, 0664);
+  FILE *fp = tmp_file.file_ptr();
+  if (!fp) {
     FS_LOG_ERROR("Failed to open temporary file for writing: "
                  << tmp_path << " - " << std::strerror(errno));
     return false;
   }
 
-  // Apply the custom buffer to the file stream
-  ofs.rdbuf()->pubsetbuf(thread_write_buffer.data(), WRITE_BUFFER_SIZE);
-
-  // Write file contents
-  ofs.write(reinterpret_cast<const char*>(buf.ptr), buf.size);
-  if (!ofs) {
-    FS_LOG_ERROR("Failed to write to temporary file: " << tmp_path << " - "
-                                                       << std::strerror(errno));
-    std::remove(tmp_path.c_str());  // Clean up temp file
+  // Write data using unbuffered I/O for better performance
+  ssize_t amount_writen = tmp_file.write_unbuffered(buf.ptr, buf.size);
+  if (amount_writen == -1) {
+    FS_LOG_ERROR("Failed to write data to temporary file:" << tmp_path << " - "
+                                                           << std::strerror(errno));
     return false;
+
+  }
+  else if (amount_writen < buf.size) {
+    FS_LOG_ERROR("Failed to write data to temporary file:" << tmp_path
+                                                           << "Wanted " << buf.size << "byte(s) but found "
+                                                           << amount_writen);
   }
 
-  ofs.flush();
-  if (!ofs) {
-    FS_LOG_ERROR("Failed to flush data to temporary file: "
-                 << tmp_path << " - " << std::strerror(errno));
-    return false;
-  }
 
   // Atomically rename temp file to final target name after a successful write
-  if (std::rename(tmp_path.c_str(), target_path.c_str()) != 0) {
+  if (! tmp_file.rename(target_path)) {
     FS_LOG_ERROR("Failed to rename " << tmp_path << " to " << target_path
                                      << " - " << std::strerror(errno));
-    std::remove(tmp_path.c_str());
     return false;
   }
 

--- a/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_io/file_io.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_io/file_io.cpp
@@ -119,10 +119,11 @@ bool TmpFile::rename(const std::string& new_path) {
   if (!flush()) return false;
 
   if (m_o_tmpfile) {
-    // For O_TMPFILE, use linkat with AT_EMPTY_PATH to link the fd to the filesystem
+    // For O_TMPFILE, use linkat with AT_EMPTY_PATH to link the fd to the filesystem.
+    // EEXIST means another thread/process already wrote the same file — treat as success.
     int file_fd = fd();
     if (linkat(file_fd, "", AT_FDCWD, new_path.c_str(), AT_EMPTY_PATH) != 0) {
-      return false;
+      if (errno != EEXIST) return false;
     }
   } else {
     // Standard rename for regular temporary files

--- a/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_io/file_io.hpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/backends/fs_io/file_io.hpp
@@ -16,8 +16,13 @@
 
 #pragma once
 
+#include <cstring>
 #include <string>
+#include <unistd.h>
 #include <vector>
+#include <cstdio>
+#include <fcntl.h>
+#include <filesystem>
 #include <cuda_runtime.h>
 #include <torch/extension.h>
 
@@ -25,10 +30,82 @@
 #include "tensor_copier.hpp"
 #include "storage_handler.hpp"
 
+#include <stdexcept>
+#include <string>
+
+// -------------------------------------------------------------------
+// RAII guard for temporary file cleanup
+// -------------------------------------------------------------------
+// Ensures temporary files are automatically cleaned up on scope exit
+// unless explicitly released after successful operations (e.g., rename)
+class TmpFile {
+  public:
+  // Constructor for with UNIX open flags
+  explicit TmpFile(const std::string &path, int oflags, int mode);
+
+  ~TmpFile();
+
+  // Prevent copying
+  TmpFile(const TmpFile&) = delete;
+  TmpFile & operator=(const TmpFile &) = delete;
+
+  // Allow moving
+  TmpFile(TmpFile&& other) noexcept
+      : m_path(std::move(other.m_path)),
+        m_fp(std::exchange(other.m_fp, nullptr)),
+        m_o_tmpfile(other.m_o_tmpfile) {
+  }
+
+  TmpFile& operator=(TmpFile&& other) noexcept {
+    if (this != &other) {
+      cleanup();
+      m_path = std::move(other.m_path);
+      m_fp = std::exchange(other.m_fp, nullptr);
+      m_o_tmpfile = std::move(other.m_o_tmpfile);
+    }
+    return *this;
+  }
+
+  // Allow if (!tmp_file) to see if file is open
+  explicit operator bool() const;
+
+  // Write buffer directly to the file desciptor.
+  // If you have previous data using the C-style API, you should call flush() first.
+  // The return value is the total number of bytes written.
+  // if there is an error, returns -1 and sets errno
+  ssize_t write_unbuffered(const void *data, size_t size);
+
+  // Flush buffer to disk
+  bool flush();
+
+  // Get raw fd
+  // NOTE: Call flush() before accessing fd to ensure buffered data is written
+  int fd() const;
+
+  // Get FILE* for stdio operations
+  // NOTE: do not call close() on this file descriptor
+  FILE* file_ptr() const;
+
+  // Rename/link the temporary file to a new path
+  // If m_o_tmpfile is true, uses linkat to link the O_TMPFILE to the new path
+  // Otherwise, uses standard rename
+  // Note: linkat does not close the file descriptor, it just creates a link
+  bool rename(const std::string& new_path);
+
+
+  private:
+    void cleanup();
+    
+    std::filesystem::path m_path; // NOTE: if O_TEMPFILE is used; then this will be a directory instead
+    FILE* m_fp;
+    bool m_o_tmpfile;
+};
+
 // CPU File I/O class - uses CPU buffer for staging
 class FileIO : public StorageHandler {
  public:
-  FileIO(TensorCopier& tensor_copier) : m_tensor_copier(tensor_copier) {}
+  FileIO(TensorCopier& tensor_copier, bool o_tmpfile)
+      : m_tensor_copier(tensor_copier), m_o_tmpfile(o_tmpfile) {}
   ~FileIO() override = default;
 
   // Write blocks to file using CPU staging
@@ -50,12 +127,13 @@ class FileIO : public StorageHandler {
 
  private:
   TensorCopier& m_tensor_copier;
+  bool m_o_tmpfile;
 
   // Write a buffer to disk using a temporary file and atomic rename
-  static bool write_buffer_to_file(const StagingBufferInfo& buf,
+  bool write_buffer_to_file(const StagingBufferInfo& buf,
                                    const std::string& target_path);
 
   // Read a file into a thread-local staging buffer
-  static bool read_buffer_from_file(const std::string& path,
+  bool read_buffer_from_file(const std::string& path,
                                     StagingBufferInfo& buf);
 };

--- a/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload.cpp
@@ -59,7 +59,8 @@ StorageOffloadEngine::StorageOffloadEngine(int io_threads,
                                            std::vector<torch::Tensor>& tensors,
                                            int read_preferring_workers,
                                            const std::string& gds_mode_str,
-                                           float max_write_queued_seconds)
+                                           float max_write_queued_seconds,
+                                           bool o_tmpfile)
     : m_tensor_copier(tensors, gpu_blocks_per_file),
       m_gds_mode(parse_gds_mode(gds_mode_str)),
       m_thread_pool(
@@ -68,8 +69,9 @@ StorageOffloadEngine::StorageOffloadEngine(int io_threads,
           get_device_id(),
           read_preferring_workers),
       m_gpu_blocks_per_file(gpu_blocks_per_file),
-      m_max_write_queued_seconds(max_write_queued_seconds) {
-  init_handlers(m_gds_mode, tensors);
+      m_max_write_queued_seconds(max_write_queued_seconds),
+      o_tmpfile(o_tmpfile) {
+  init_handlers(m_gds_mode, tensors, o_tmpfile);
   FS_LOG_INFO("Dynamic write queue limit: max_write_queued_seconds="
               << m_max_write_queued_seconds
               << (m_max_write_queued_seconds <= 0 ? " (disabled)" : ""));
@@ -112,7 +114,8 @@ size_t StorageOffloadEngine::get_dynamic_write_queue_limit() const {
 // otherwise.
 void StorageOffloadEngine::init_handlers(
     GdsMode gds_mode,
-    const std::vector<torch::Tensor>& tensors) {
+    const std::vector<torch::Tensor>& tensors,
+    bool o_tmpfile) {
   std::shared_ptr<GdsFileIO> gds_io;
 
   if (gds_mode != GdsMode::DISABLED) {
@@ -124,7 +127,8 @@ void StorageOffloadEngine::init_handlers(
     gds_io = std::make_shared<GdsFileIO>(gpu_buffers,
                                          m_tensor_copier.get_block_size(),
                                          gds_mode,
-                                         m_tensor_copier);
+                                         m_tensor_copier,
+                                         o_tmpfile);
 
     if (!gds_io->is_gds_available()) {
       FS_LOG_WARN(
@@ -136,10 +140,10 @@ void StorageOffloadEngine::init_handlers(
 
   m_read_handler = (gds_io && gds_io->use_for_read())
                        ? std::shared_ptr<StorageHandler>(gds_io)
-                       : std::make_shared<FileIO>(m_tensor_copier);
+                       : std::make_shared<FileIO>(m_tensor_copier, o_tmpfile);
   m_write_handler = (gds_io && gds_io->use_for_write())
                         ? std::shared_ptr<StorageHandler>(gds_io)
-                        : std::make_shared<FileIO>(m_tensor_copier);
+                        : std::make_shared<FileIO>(m_tensor_copier, o_tmpfile);
 
   auto mode_str = [](StorageMode m) {
     switch (m) {

--- a/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload.hpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload.hpp
@@ -71,6 +71,8 @@ class StorageOffloadEngine {
   std::atomic<uint64_t> m_avg_write_duration_us{0};
   // Max seconds of queued writes before dropping (0 = disabled)
   float m_max_write_queued_seconds;
+  // Use O_TMPFILE flag for write buffer transfers to the filesystem
+  bool o_tmpfile;
   // Counter of dropped writes (for rate-limited logging)
   size_t m_dropped_writes{0};
   // Calculate staging buffer size in bytes (0 for full-GDS modes)
@@ -79,7 +81,8 @@ class StorageOffloadEngine {
                                    GdsMode gds_mode);
   // Initialize read/write handlers: GdsFileIO if available, FileIO otherwise
   void init_handlers(GdsMode gds_mode,
-                     const std::vector<torch::Tensor>& tensors);
+                     const std::vector<torch::Tensor>& tensors,
+                     bool o_tmpfile);
   // Get current device
   static int get_device_id();
 
@@ -90,7 +93,8 @@ class StorageOffloadEngine {
                        std::vector<torch::Tensor>& tensors,
                        int read_preferring_workers,
                        const std::string& gds_mode,
-                       float max_write_queued_seconds = 10.0);
+                       float max_write_queued_seconds = 10.0,
+                       bool o_tmpfile = false);
   // Return finished jobs and their success status
   std::vector<std::pair<int, bool>> get_finished();
   // Update EMA of per-file write duration (called by write workers)

--- a/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload_bindings.cpp
+++ b/kv_connectors/llmd_fs_backend/csrc/storage/storage_offload_bindings.cpp
@@ -33,13 +33,15 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                     std::vector<torch::Tensor>&,
                     int,
                     const std::string&,
-                    float>(),
+                    float,
+                    bool>(),
            py::arg("io_threads"),
            py::arg("gpu_blocks_per_file"),
            py::arg("tensors"),
            py::arg("read_preferring_workers"),
            py::arg("gds_mode") = "disabled",
            py::arg("max_write_queued_seconds"),
+           py::arg("o_tmpfile") = false,
 
            "Create a StorageOffloadEngine instance for asynchronous KV-cache "
            "transfers between GPU memory and shared storage. "
@@ -58,7 +60,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            "  gds_mode: GDS operation mode (see GdsMode in storage_types.hpp). "
            "Defaults to 'disabled'.\n"
            "  max_write_queued_seconds: Max seconds of queued writes before "
-           "dropping. 0 disables the limit.\n")
+           "dropping. 0 disables the limit.\n"
+           "  o_tmpfile: Use O_TMPFILE for atomic file creation. "
+           "Defaults to false.\n")
 
       .def("get_finished",
            &StorageOffloadEngine::get_finished,

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -29,6 +29,7 @@ from llmd_fs_backend.worker import (
     DEFAULT_MAX_WRITE_QUEUED_SECONDS,
     DEFAULT_READ_PREFERRING_WORKERS_RATIO,
     DEFAULT_THREADS_PER_GPU,
+    DEFAULT_O_TMPFILE,
     StorageOffloadingHandlers,
 )
 
@@ -81,6 +82,10 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
             self.extra_config.get(
                 "max_write_queued_seconds", DEFAULT_MAX_WRITE_QUEUED_SECONDS
             )
+        )
+
+        self.o_tmpfile = bool(
+            self.extra_config.get("o_tmpfile", DEFAULT_O_TMPFILE)
         )
 
         parallel_config = vllm_config.parallel_config

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/worker.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/worker.py
@@ -59,6 +59,7 @@ DEFAULT_MAX_STAGING_MEMORY_GB = 150
 DEFAULT_THREADS_PER_GPU = 64
 DEFAULT_READ_PREFERRING_WORKERS_RATIO = 0.75
 DEFAULT_MAX_WRITE_QUEUED_SECONDS = 10.0
+DEFAULT_O_TMPFILE = False
 
 
 class BaseStorageOffloadingHandler(OffloadingHandler):
@@ -299,6 +300,8 @@ class StorageOffloadingHandlers:
             )
             gds_mode = "disabled"
 
+        o_tmpfile = extra_config.get("o_tmpfile", DEFAULT_O_TMPFILE)
+
         # Compute staging memory buffer size
         buffer_size_mb = self._compute_buffer_size_mb(tensors, gpu_blocks_per_file)
 
@@ -330,6 +333,7 @@ class StorageOffloadingHandlers:
             max_write_queued_seconds=max_write_queued_seconds,
             extra_config=extra_config,
             gds_mode=gds_mode,
+            o_tmpfile=o_tmpfile,
         )
 
         # Compute per-GPU-block size in bytes for metrics across all tensors.
@@ -396,6 +400,7 @@ class StorageOffloadingHandlers:
         max_write_queued_seconds: float,
         extra_config: dict,
         gds_mode: str,
+        o_tmpfile: bool,
     ) -> StorageEngine:
         return storage_offload.StorageOffloadEngine(
             io_threads,
@@ -404,4 +409,5 @@ class StorageOffloadingHandlers:
             read_preferring_workers,
             gds_mode,
             max_write_queued_seconds,
+            o_tmpfile,
         )

--- a/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/test_throughput.py
@@ -72,6 +72,7 @@ def run_throughput_test(
     threads_per_gpu: int = 24,
     with_gpu_prefix_cache: bool = False,
     storage_type: str = "fs",
+    o_tmpfile: bool = False,
 ) -> tuple[float, float, float, float, float]:
     """
     Run sustained throughput test: cold -> hot -> steady-state.
@@ -93,6 +94,7 @@ def run_throughput_test(
         cpu_block_size=cpu_block_size,
         threads_per_gpu=threads_per_gpu,
         storage_type=storage_type,
+        o_tmpfile=o_tmpfile,
     )
 
     llm = LLM(
@@ -310,6 +312,14 @@ if __name__ == "__main__":
         choices=LOG_LEVELS,
         help=f"Set STORAGE_LOG_LEVEL for storage tier (one of {LOG_LEVELS})",
     )
+    parser.add_argument(
+        "--o-tmpfile",
+        action="store_true",
+        help=(
+            "Enable O_TMPFILE flag for temporary file creation. "
+            "Only meaningful for --backend=storage / multi-cpu-storage."
+        ),
+    )
     args = parser.parse_args()
 
     try:
@@ -328,6 +338,7 @@ if __name__ == "__main__":
             threads_per_gpu=args.threads_per_gpu,
             with_gpu_prefix_cache=args.with_gpu_prefix_cache,
             storage_type=args.storage_type,
+            o_tmpfile=args.o_tmpfile,
         )
     finally:
         cleanup_storage_dir(args.storage_path)

--- a/kv_connectors/llmd_fs_backend/tests/performance/utils.py
+++ b/kv_connectors/llmd_fs_backend/tests/performance/utils.py
@@ -97,6 +97,7 @@ def get_kv_transfer_config(
     threads_per_gpu: int = 24,
     max_staging_memory_gb: int = 150,
     storage_type: str = "fs",
+    o_tmpfile: bool = False,
 ) -> KVTransferConfig | None:
     """
     Build a KVTransferConfig for the specified backend.
@@ -116,6 +117,7 @@ def get_kv_transfer_config(
         max_staging_memory_gb: Max CPU staging buffer for the storage tier.
         storage_type: Storage implementation flavor — "fs" (default, CPU
             staging) or "gds" (full read/write GPUDirect Storage).
+        o_tmpfile: Enable O_TMPFILE flag for temporary file creation (default: False).
 
     Returns:
         A KVTransferConfig, or None if backend is "base" or "gpu".
@@ -145,6 +147,7 @@ def get_kv_transfer_config(
                 "max_staging_memory_gb": max_staging_memory_gb,
                 "gds_mode": gds_mode,
                 "read_preferring_ratio": 0.75,
+                "o_tmpfile": o_tmpfile,
             },
         )
 
@@ -185,6 +188,7 @@ def get_kv_transfer_config(
                             "block_size": storage_block_size,
                             "max_staging_memory_gb": max_staging_memory_gb,
                             "gds_mode": gds_mode,
+                            "o_tmpfile": o_tmpfile,
                         },
                     },
                 ],


### PR DESCRIPTION
Give fs connector more robust temporary file handling


For our distributed file system, we found that using O_TMPFILE provides less synchronization overhead when creating files (because the inode is anonymous) and allows better offloading performance. Additionally, we moved away from C++ ofstream user-space buffering because: 
- C++ std does not expose file descriptors needed for O_TMPFILE
- We achieve better performance by skipping an intermediate user space buffer; this is justified because kv cache offload files typically exceed multiple MiB.

Because we switched out the default write operation, I wrote a custom micro-benchmark (which I can share upon request) to make sure that there was no performance degradation in the regular path (not using O_TMPFILE)
To share the micobenchmarking results:
```
# c++ ofstream is implemented as a copy of the current llm-d implementation
# 5 iterations means each thread writes 5 files
# The chunk size means that for code using the write() system call, we break the write down into 1MiB write() calls
# stdio buffering is the size of the custom user space buffer passed to fwrite (see setvbuf()) and c++ ofstream (see pubsetbuf())
# The test was completed on IBM's distributed file system (GPFS) on a single client


I/O PERFORMANCE BENCHMARK
=============================================================================
Output directory: /ibm/fs1-remote/kv-cache
File size: 50 MiB
Iterations: 5
Chunk size: 1048576 bytes (1 MiB; stdio buffering is also 1MiB)
=============================================================================

SINGLE-THREADED BASELINE
-----------------------------------------------------------------------------
Method                       Latency           Throughput
-----------------------------------------------------------------------------
C++ ofstream           0.0121 s       4129.39 MB/s
C fwrite               0.0122 s       4108.06 MB/s
Unbuffered write       0.0112 s       4457.81 MB/s

=============================================================================
MULTI-THREADED SCALING
=============================================================================

Running 12 tests...
  [1/12] Testing C++ ofstream with 1 thread(s)... 3987.14 MB/s
  [2/12] Testing C++ ofstream with 4 thread(s)... 9250.89 MB/s
  [3/12] Testing C++ ofstream with 16 thread(s)... 46759.7 MB/s
  [4/12] Testing C++ ofstream with 64 thread(s)... 76768 MB/s
  [5/12] Testing C fwrite with 1 thread(s)... 4174.02 MB/s
  [6/12] Testing C fwrite with 4 thread(s)... 9420.42 MB/s
  [7/12] Testing C fwrite with 16 thread(s)... 46842 MB/s
  [8/12] Testing C fwrite with 64 thread(s)... 51335.1 MB/s
  [9/12] Testing Unbuffered write with 1 thread(s)... 4467 MB/s
  [10/12] Testing Unbuffered write with 4 thread(s)... 17311.7 MB/s
  [11/12] Testing Unbuffered write with 16 thread(s)... 51224.4 MB/s
  [12/12] Testing Unbuffered write with 64 thread(s)... 83523.4 MB/s

```

In addition, I tested the pytest throughput tests with O_TMP enabled, and saw a small improvement when testing on a single gpu:


```
jterner3@css-host-191:~/dev/write_offloading_options$ cat buffered_cpp_throughput.txt | ./write_buffer_to_file_avg.sh
24.8448
jterner3@css-host-191:~/dev/write_offloading_options$ cat no_buffer_1MiB_chunk.txt | ./write_buffer_to_file_avg.sh
21.3199
jterner3@css-host-191:~/dev/write_offloading_options$ cat no_buffer_otmp_1MiB_chunk.txt | ./write_buffer_to_file_avg.sh
19.7344
```
Code for write_buffer_to_file_avg.sh:
```bash
#!/bin/bash
grep write_buffer_to_file | perl -ne '/took (\d+.\d+)/ && print "$1\n";'  | awk '{ sum += $1 } END { print (NR > 0 ? sum / NR : 0) }'
```

where these files were produced with `python -m  tests.performance.test_throughput --model Qwen/Qwen3-8b  --num-requests 300 --num-tokens 12000 --tp-size 1 --log-level trace --cpu-block-size 256 2>&1 --storage-path /ibm/fs1-remote/kvc-cache`