### PR TITLE
fix(sglang): decode token_ids as typed []uint32 with bigram support

### DIFF
--- a/pkg/kvevents/engineadapter/sglang_adapter.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v5/msgpcode"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvevents"
 )
@@ -107,12 +108,79 @@ type msgpackSGLangBlockStoredEvent struct {
 	Tag             string
 	BlockHashes     []any
 	ParentBlockHash any
-	TokenIds        []uint32
+	TokenIds        sglangTokenIDs
 	BlockSize       int
 	LoraID          *int    `msgpack:",omitempty"`
 	Medium          *string `msgpack:",omitempty"`
 	LoraName        *string `msgpack:",omitempty"`
 	ExtraKeys       []any   `msgpack:",omitempty"`
+}
+
+// sglangTokenIDs decodes BlockStored.token_ids, which SGLang emits in two
+// shapes: flat [t0, t1, ...] in normal mode, or bigram [[t0,t1],[t1,t2],...]
+// when EAGLE-family speculative decoding is enabled. The wire codes for the
+// two shapes are disjoint (int vs array), so the decoder picks the branch
+// from the first element. The bigram branch keeps the second element of each
+// pair, which collapses overlapping pairs back to a unique token sequence
+// (equivalent to the engine's raw[1:]).
+//
+// See sglang/python/sglang/srt/mem_cache/events.py:_record_store_event and
+// the is_bigram flag set from is_eagle in radix_cache.py / hiradix_cache.py.
+type sglangTokenIDs []uint32
+
+func (t *sglangTokenIDs) DecodeMsgpack(dec *msgpack.Decoder) error {
+	n, err := dec.DecodeArrayLen()
+	if err != nil {
+		return err
+	}
+	if n <= 0 {
+		*t = nil
+		return nil
+	}
+
+	code, err := dec.PeekCode()
+	if err != nil {
+		return err
+	}
+	isBigram := msgpcode.IsFixedArray(code) ||
+		code == msgpcode.Array16 ||
+		code == msgpcode.Array32
+
+	out := make([]uint32, n)
+	if isBigram {
+		for i := 0; i < n; i++ {
+			inner, err := dec.DecodeArrayLen()
+			if err != nil {
+				return fmt.Errorf("token_ids bigram[%d]: %w", i, err)
+			}
+			if inner < 2 {
+				return fmt.Errorf("token_ids bigram[%d]: pair too short, len=%d", i, inner)
+			}
+			if err := dec.Skip(); err != nil { // prev token (overlaps with previous pair)
+				return fmt.Errorf("token_ids bigram[%d][0]: %w", i, err)
+			}
+			v, err := dec.DecodeUint32()
+			if err != nil {
+				return fmt.Errorf("token_ids bigram[%d][1]: %w", i, err)
+			}
+			for k := 2; k < inner; k++ {
+				if err := dec.Skip(); err != nil {
+					return fmt.Errorf("token_ids bigram[%d][%d]: %w", i, k, err)
+				}
+			}
+			out[i] = v
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			v, err := dec.DecodeUint32()
+			if err != nil {
+				return fmt.Errorf("token_ids[%d]: %w", i, err)
+			}
+			out[i] = v
+		}
+	}
+	*t = out
+	return nil
 }
 
 type msgpackSGLangBlockRemovedEvent struct {

--- a/pkg/kvevents/engineadapter/sglang_adapter.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter.go
@@ -116,16 +116,16 @@ type msgpackSGLangBlockStoredEvent struct {
 	ExtraKeys       []any   `msgpack:",omitempty"`
 }
 
-// sglangTokenIDs decodes BlockStored.token_ids, which SGLang emits in two
-// shapes: flat [t0, t1, ...] in normal mode, or bigram [[t0,t1],[t1,t2],...]
-// when EAGLE-family speculative decoding is enabled. The wire codes for the
-// two shapes are disjoint (int vs array), so the decoder picks the branch
-// from the first element. The bigram branch keeps the second element of each
-// pair, which collapses overlapping pairs back to a unique token sequence
-// (equivalent to the engine's raw[1:]).
+// sglangTokenIDs decodes BlockStored.token_ids, which SGLang emits as flat
+// [t0, t1, ...] normally or as bigram [[t0,t1],[t1,t2],...] under EAGLE-family
+// speculative decoding (see sglang events.py:_record_store_event). The wire
+// codes are disjoint (int vs array) so the branch is picked by peeking the
+// first element.
 //
-// See sglang/python/sglang/srt/mem_cache/events.py:_record_store_event and
-// the is_bigram flag set from is_eagle in radix_cache.py / hiradix_cache.py.
+// The bigram branch flattens N pairs back to N+1 raw tokens. The trailing
+// overlap with the next page is dropped by kvblock.chunkTokens as a partial
+// block, so the resulting canonical block hashes match the flat-token request
+// path -- no bigram awareness is needed in token_processor.go.
 type sglangTokenIDs []uint32
 
 func (t *sglangTokenIDs) DecodeMsgpack(dec *msgpack.Decoder) error {
@@ -146,59 +146,69 @@ func (t *sglangTokenIDs) DecodeMsgpack(dec *msgpack.Decoder) error {
 		code == msgpcode.Array16 ||
 		code == msgpcode.Array32
 
-	out := make([]uint32, count)
 	if isBigram {
+		out := make([]uint32, count+1)
 		if err := decodeBigramTokenIDs(dec, out); err != nil {
 			return err
 		}
-	} else {
-		for i := 0; i < count; i++ {
-			v, err := dec.DecodeUint32()
-			if err != nil {
-				return fmt.Errorf("token_ids[%d]: %w", i, err)
-			}
-			out[i] = v
+		*t = out
+		return nil
+	}
+
+	out := make([]uint32, count)
+	for i := 0; i < count; i++ {
+		v, err := dec.DecodeUint32()
+		if err != nil {
+			return fmt.Errorf("token_ids[%d]: %w", i, err)
 		}
+		out[i] = v
 	}
 	*t = out
 	return nil
 }
 
-// decodeBigramTokenIDs decodes the bigram-shaped token_ids array
-// ([[t0,t1],[t1,t2],...]) into out by keeping the second element of each pair,
-// which collapses overlapping pairs back to the underlying token sequence.
+// decodeBigramTokenIDs flattens N overlapping pairs into N+1 raw tokens;
+// out must be sized accordingly. Only the first pair contributes its head;
+// subsequent pair heads overlap with the previous pair's tail.
 func decodeBigramTokenIDs(dec *msgpack.Decoder, out []uint32) error {
-	for i := range out {
-		v, err := decodeBigramPair(dec, i)
+	pairs := len(out) - 1
+	for i := 0; i < pairs; i++ {
+		head, tail, err := decodeBigramPair(dec, i)
 		if err != nil {
 			return err
 		}
-		out[i] = v
+		if i == 0 {
+			out[0] = head
+		}
+		out[i+1] = tail
 	}
 	return nil
 }
 
-func decodeBigramPair(dec *msgpack.Decoder, i int) (uint32, error) {
+// decodeBigramPair decodes one [prev, curr] inner array. Extra trailing
+// elements (inner > 2) are tolerated; inner < 2 is an error.
+func decodeBigramPair(dec *msgpack.Decoder, i int) (uint32, uint32, error) {
 	inner, err := dec.DecodeArrayLen()
 	if err != nil {
-		return 0, fmt.Errorf("token_ids bigram[%d]: %w", i, err)
+		return 0, 0, fmt.Errorf("token_ids bigram[%d]: %w", i, err)
 	}
 	if inner < 2 {
-		return 0, fmt.Errorf("token_ids bigram[%d]: pair too short, len=%d", i, inner)
+		return 0, 0, fmt.Errorf("token_ids bigram[%d]: pair too short, len=%d", i, inner)
 	}
-	if err := dec.Skip(); err != nil { // prev token (overlaps with previous pair)
-		return 0, fmt.Errorf("token_ids bigram[%d][0]: %w", i, err)
-	}
-	v, err := dec.DecodeUint32()
+	head, err := dec.DecodeUint32()
 	if err != nil {
-		return 0, fmt.Errorf("token_ids bigram[%d][1]: %w", i, err)
+		return 0, 0, fmt.Errorf("token_ids bigram[%d][0]: %w", i, err)
+	}
+	tail, err := dec.DecodeUint32()
+	if err != nil {
+		return 0, 0, fmt.Errorf("token_ids bigram[%d][1]: %w", i, err)
 	}
 	for k := 2; k < inner; k++ {
 		if err := dec.Skip(); err != nil {
-			return 0, fmt.Errorf("token_ids bigram[%d][%d]: %w", i, k, err)
+			return 0, 0, fmt.Errorf("token_ids bigram[%d][%d]: %w", i, k, err)
 		}
 	}
-	return v, nil
+	return head, tail, nil
 }
 
 type msgpackSGLangBlockRemovedEvent struct {

--- a/pkg/kvevents/engineadapter/sglang_adapter.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter.go
@@ -129,11 +129,11 @@ type msgpackSGLangBlockStoredEvent struct {
 type sglangTokenIDs []uint32
 
 func (t *sglangTokenIDs) DecodeMsgpack(dec *msgpack.Decoder) error {
-	n, err := dec.DecodeArrayLen()
+	count, err := dec.DecodeArrayLen()
 	if err != nil {
 		return err
 	}
-	if n <= 0 {
+	if count <= 0 {
 		*t = nil
 		return nil
 	}
@@ -146,32 +146,13 @@ func (t *sglangTokenIDs) DecodeMsgpack(dec *msgpack.Decoder) error {
 		code == msgpcode.Array16 ||
 		code == msgpcode.Array32
 
-	out := make([]uint32, n)
+	out := make([]uint32, count)
 	if isBigram {
-		for i := 0; i < n; i++ {
-			inner, err := dec.DecodeArrayLen()
-			if err != nil {
-				return fmt.Errorf("token_ids bigram[%d]: %w", i, err)
-			}
-			if inner < 2 {
-				return fmt.Errorf("token_ids bigram[%d]: pair too short, len=%d", i, inner)
-			}
-			if err := dec.Skip(); err != nil { // prev token (overlaps with previous pair)
-				return fmt.Errorf("token_ids bigram[%d][0]: %w", i, err)
-			}
-			v, err := dec.DecodeUint32()
-			if err != nil {
-				return fmt.Errorf("token_ids bigram[%d][1]: %w", i, err)
-			}
-			for k := 2; k < inner; k++ {
-				if err := dec.Skip(); err != nil {
-					return fmt.Errorf("token_ids bigram[%d][%d]: %w", i, k, err)
-				}
-			}
-			out[i] = v
+		if err := decodeBigramTokenIDs(dec, out); err != nil {
+			return err
 		}
 	} else {
-		for i := 0; i < n; i++ {
+		for i := 0; i < count; i++ {
 			v, err := dec.DecodeUint32()
 			if err != nil {
 				return fmt.Errorf("token_ids[%d]: %w", i, err)
@@ -181,6 +162,43 @@ func (t *sglangTokenIDs) DecodeMsgpack(dec *msgpack.Decoder) error {
 	}
 	*t = out
 	return nil
+}
+
+// decodeBigramTokenIDs decodes the bigram-shaped token_ids array
+// ([[t0,t1],[t1,t2],...]) into out by keeping the second element of each pair,
+// which collapses overlapping pairs back to the underlying token sequence.
+func decodeBigramTokenIDs(dec *msgpack.Decoder, out []uint32) error {
+	for i := range out {
+		v, err := decodeBigramPair(dec, i)
+		if err != nil {
+			return err
+		}
+		out[i] = v
+	}
+	return nil
+}
+
+func decodeBigramPair(dec *msgpack.Decoder, i int) (uint32, error) {
+	inner, err := dec.DecodeArrayLen()
+	if err != nil {
+		return 0, fmt.Errorf("token_ids bigram[%d]: %w", i, err)
+	}
+	if inner < 2 {
+		return 0, fmt.Errorf("token_ids bigram[%d]: pair too short, len=%d", i, inner)
+	}
+	if err := dec.Skip(); err != nil { // prev token (overlaps with previous pair)
+		return 0, fmt.Errorf("token_ids bigram[%d][0]: %w", i, err)
+	}
+	v, err := dec.DecodeUint32()
+	if err != nil {
+		return 0, fmt.Errorf("token_ids bigram[%d][1]: %w", i, err)
+	}
+	for k := 2; k < inner; k++ {
+		if err := dec.Skip(); err != nil {
+			return 0, fmt.Errorf("token_ids bigram[%d][%d]: %w", i, k, err)
+		}
+	}
+	return v, nil
 }
 
 type msgpackSGLangBlockRemovedEvent struct {

--- a/pkg/kvevents/engineadapter/sglang_adapter_test.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter_test.go
@@ -183,15 +183,13 @@ func TestSGLangBlockStored_MinimalFields(t *testing.T) {
 	assert.Nil(t, blockStored.ExtraKeys)
 }
 
-// TestSGLangBlockStored_BigramTokenIDs verifies the decoder collapses the
-// nested [[prev, curr], ...] payload that SGLang emits when EAGLE-family
-// speculative decoding is enabled. Each pair's second element is kept, which
-// matches the engine's raw[1:] token sequence.
+// TestSGLangBlockStored_BigramTokenIDs verifies the bigram payload SGLang
+// emits under EAGLE-family speculative decoding flattens back to N+1 raw
+// tokens (raw[0:N+1]), preserving the page-head token.
 func TestSGLangBlockStored_BigramTokenIDs(t *testing.T) {
 	adapter := NewSGLangAdapter()
 
-	// Raw token stream on the engine side: [10, 11, 12, 13].
-	// Bigram view materialised by events.py: [(10,11), (11,12), (12,13)].
+	// Raw [10, 11, 12, 13] materialises in events.py as [(10,11),(11,12),(12,13)].
 	event := []any{
 		"BlockStored",
 		[]any{uint64(700)},
@@ -210,13 +208,98 @@ func TestSGLangBlockStored_BigramTokenIDs(t *testing.T) {
 	require.NoError(t, err)
 
 	result, err := decodeEvent(rawBytes, adapter.eventConverters)
-	require.NoError(t, err, "bigram BlockStored should decode successfully")
+	require.NoError(t, err)
 	require.NotNil(t, result)
 
 	blockStored, ok := result.(*kvevents.BlockStoredEvent)
 	require.True(t, ok)
-	assert.Equal(t, []uint32{11, 12, 13}, blockStored.Tokens)
+	assert.Equal(t, []uint32{10, 11, 12, 13}, blockStored.Tokens)
 	assert.Equal(t, "GPU", blockStored.DeviceTier)
+}
+
+// TestSGLangBlockStored_EmptyTokenIDs verifies an empty token_ids
+// short-circuits before the branch-picking peek (which would otherwise read
+// past the array).
+func TestSGLangBlockStored_EmptyTokenIDs(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{
+		"BlockStored",
+		[]any{uint64(800)},
+		uint64(799),
+		[]any{},
+		16,
+		nil,
+		"GPU",
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	blockStored, ok := result.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Nil(t, blockStored.Tokens)
+}
+
+// TestSGLangBlockStored_BigramMalformedPair verifies a bigram inner array
+// shorter than 2 elements is rejected.
+func TestSGLangBlockStored_BigramMalformedPair(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{
+		"BlockStored",
+		[]any{uint64(810)},
+		uint64(809),
+		[]any{
+			[]any{uint32(20), uint32(21)},
+			[]any{uint32(21)},
+		},
+		16,
+		nil,
+		"GPU",
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	_, err = decodeEvent(rawBytes, adapter.eventConverters)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pair too short")
+}
+
+// TestSGLangBlockStored_BigramOversizedPair verifies the defensive skip path
+// for inner arrays longer than 2 elements.
+func TestSGLangBlockStored_BigramOversizedPair(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	event := []any{
+		"BlockStored",
+		[]any{uint64(820)},
+		uint64(819),
+		[]any{
+			[]any{uint32(30), uint32(31), uint32(999)},
+			[]any{uint32(31), uint32(32), uint32(999), "extra"},
+			[]any{uint32(32), uint32(33)},
+		},
+		16,
+		nil,
+		"GPU",
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	blockStored, ok := result.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint32{30, 31, 32, 33}, blockStored.Tokens)
 }
 
 // TestSGLangBlockStored_TooFewFields tests that fewer than minimum fields returns an error.

--- a/pkg/kvevents/engineadapter/sglang_adapter_test.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter_test.go
@@ -183,6 +183,42 @@ func TestSGLangBlockStored_MinimalFields(t *testing.T) {
 	assert.Nil(t, blockStored.ExtraKeys)
 }
 
+// TestSGLangBlockStored_BigramTokenIDs verifies the decoder collapses the
+// nested [[prev, curr], ...] payload that SGLang emits when EAGLE-family
+// speculative decoding is enabled. Each pair's second element is kept, which
+// matches the engine's raw[1:] token sequence.
+func TestSGLangBlockStored_BigramTokenIDs(t *testing.T) {
+	adapter := NewSGLangAdapter()
+
+	// Raw token stream on the engine side: [10, 11, 12, 13].
+	// Bigram view materialised by events.py: [(10,11), (11,12), (12,13)].
+	event := []any{
+		"BlockStored",
+		[]any{uint64(700)},
+		uint64(699),
+		[]any{
+			[]any{uint32(10), uint32(11)},
+			[]any{uint32(11), uint32(12)},
+			[]any{uint32(12), uint32(13)},
+		},
+		16,
+		nil,
+		"GPU",
+	}
+
+	rawBytes, err := msgpack.Marshal(event)
+	require.NoError(t, err)
+
+	result, err := decodeEvent(rawBytes, adapter.eventConverters)
+	require.NoError(t, err, "bigram BlockStored should decode successfully")
+	require.NotNil(t, result)
+
+	blockStored, ok := result.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint32{11, 12, 13}, blockStored.Tokens)
+	assert.Equal(t, "GPU", blockStored.DeviceTier)
+}
+
 // TestSGLangBlockStored_TooFewFields tests that fewer than minimum fields returns an error.
 func TestSGLangBlockStored_TooFewFields(t *testing.T) {
 	adapter := NewSGLangAdapter()


### PR DESCRIPTION
## Summary

`SGLangAdapter` currently fails to decode `BlockStored` events when the underlying SGLang engine has EAGLE-family speculative decoding enabled (`--speculative-algorithm EAGLE | EAGLE3 | FROZEN_KV_MTP`). In that mode SGLang emits `token_ids` as a **nested array of bigram pairs** rather than a flat int list, which the existing `[]uint32` msgpack target cannot satisfy — every BlockStored event from such pods is dropped with a decode error.

This PR teaches `sglang_adapter.go` to handle both wire shapes via a typed `msgpack.CustomDecoder`, with no `[]any` boxing on the hot path.

### The two shapes

SGLang's `mem_cache/events.py:_record_store_event` materialises `token_ids` differently depending on whether the request's `RadixKey` is in bigram mode:

| Mode | Wire payload | Trigger |
|---|---|---|
| Flat | `[t0, t1, t2, ...]` | normal inference |
| Bigram | `[[t0, t1], [t1, t2], [t2, t3], ...]` | `is_bigram = is_eagle == True`, i.e. EAGLE / EAGLE3 / FROZEN_KV_MTP |

`is_bigram` is set in `radix_cache.py`, `hiradix_cache.py`, `unified_radix_cache.py`, and `swa_radix_cache.py` whenever the cache was constructed with `is_eagle=True`. The tuple form has been the wire contract since `events.py` was introduced in [sgl-project/sglang#23678](https://github.com/sgl-project/sglang/pull/23678) (the in-code comment explicitly notes it preserves the historical EAGLE event payload after [#23106](https://github.com/sgl-project/sglang/pull/23106) made bigram an O(1) flag).

Pairs overlap on the boundary token, so collapsing each pair to its second element gives back the engine's `raw[1:]` token sequence — exactly the prefix the indexer needs.

### The fix

A new `sglangTokenIDs` (alias of `[]uint32`) implements `msgpack.CustomDecoder`:

1. `DecodeArrayLen` to read the outer count.
2. `PeekCode` on the first element — `FixArray | Array16 | Array32` ⇒ bigram, otherwise flat.
3. Bigram branch: per pair, `Skip()` the previous token and `DecodeUint32()` the current; defensive `Skip()` for any future trailing fields.
4. Flat branch: straight `DecodeUint32()` per element.

This eliminates the prior `[]any` + `flattenTokenIDs([]any)` + `toUint32(any)` boxing chain (three layers of reflect / type-switch per token) and replaces it with a single typed allocation per event. The dead helpers go away.

## Test plan

- [x] New `TestSGLangBlockStored_BigramTokenIDs` round-trips `[[10,11],[11,12],[12,13]]` and asserts the decoder yields `[11, 12, 13]` (= `raw[1:]`).
- [x] All existing `TestSGLang*` cases (FullFields / 7Fields / MinimalFields / TooFewFields / BlockRemoved / AllBlocksCleared / UnknownTag / ShardingKey / ParseMessage) remain green — flat-mode wire is unchanged.
- [x] `go test ./pkg/kvevents/engineadapter/ -count=1` passes.
- [x] `go vet ./pkg/kvevents/engineadapter/...` clean.

## Notes for reviewers

- No config flag was added. Shape detection is purely content-driven on the wire (the two msgpack codes are disjoint), so it works for mixed-pod pools where some pods run EAGLE and others don't — no operator-side knob to misconfigure.
- The `BlockStored.token_ids: list[int]` type annotation in SGLang's `kv_events.py` is misleading; the bigram payload violates it. That mismatch is what led the original adapter (PR #443) — modelled on the "SGLang ≈ vLLM wire format" assumption — to type the field as `[]uint32`. PR #484 fixed an analogous issue on the vLLM side; this is the SGLang counterpart it explicitly deferred.