### PR TITLE
fix(make): export EXAMPLE variable for sub-make invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -525,6 +525,7 @@ EXAMPLE ?= bin/examples/offline
 else
 EXAMPLE := bin/examples/$(EXAMPLE_FROM_GOALS)
 endif
+export EXAMPLE
 
 # Allow short example names to appear on the command line without being
 # interpreted as missing targets.


### PR DESCRIPTION
## Summary

`make run-example kv_cache_index` silently ran `offline` instead.

## Root Cause

`run-example` calls sub-makes via `$(MAKE)`, but Make doesn't pass internal variables to sub-makes by default.

The sub-make re-evaluates `EXAMPLE` from `MAKECMDGOALS`. Its command is `make run-example-only` (one word), so `$(word 2,$(MAKECMDGOALS))` is empty and it falls back to the default `offline`.

## Fix

Added `export EXAMPLE` so the value is inherited by sub-makes as an environment variable.

## Why CI didn't catch this

CI calls `make run-example-only <name>` directly in `hack/verify-examples.sh`, bypassing the `run-example` wrapper entirely. `run-example-only` receives the full argument list, so `MAKECMDGOALS` is correct. Only the `run-example` wrapper (used by local developers) triggers this bug.

## Impact

| Command | Before | After |
|---------|--------|-------|
| `make run-example kv_cache_index` | silently ran `offline` | correctly runs `kv_cache_index` |
| `make run-example online` | silently ran `offline` | correctly runs `online` |
| `make run-example` (no arg) | ran `offline` | no change |