### PR TITLE
feat(kvevents): trace raw message processing

### DIFF
--- a/hack/verify-examples.sh
+++ b/hack/verify-examples.sh
@@ -2,15 +2,18 @@
 # verify-examples.sh: Verify example builds and basic runtime checks for examples.
 set -euo pipefail
 
+# Cold CI runners can spend most of the old 30s window initializing the tokenizer.
+EXAMPLE_TIMEOUT_SECONDS="${EXAMPLE_TIMEOUT_SECONDS:-90}"
+
 fail() {
   echo "[FAIL] $1" >&2
   exit 1
 }
 
-# Wait up to 30s for a pattern to appear in a log file; returns 1 on timeout.
+# Wait up to EXAMPLE_TIMEOUT_SECONDS for a pattern to appear in a log file; returns 1 on timeout.
 wait_for_log() {
   local log=$1 pattern=$2
-  for i in {1..30}; do
+  for ((i = 0; i < EXAMPLE_TIMEOUT_SECONDS; i++)); do
     grep -q "$pattern" "$log" 2>/dev/null && return 0
     sleep 1
   done
@@ -27,7 +30,7 @@ trap 'make stop-tokenizer' EXIT
 
 # 2. Test offline example
 echo "[INFO] Running offline example..."
-timeout 30s make run-example-only offline >offline.log 2>&1 &
+timeout "${EXAMPLE_TIMEOUT_SECONDS}s" make run-example-only offline >offline.log 2>&1 &
 pid=$!
 wait_for_log offline.log 'Events demo completed.' || { cat offline.log; fail "offline example did not complete successfully."; }
 kill -INT "$pid" 2>/dev/null || true
@@ -36,7 +39,7 @@ echo "[OK] offline example completed."
 
 # 3. Test online example
 echo "[INFO] Running online example..."
-timeout 30s make run-example-only online >online.log 2>&1 &
+timeout "${EXAMPLE_TIMEOUT_SECONDS}s" make run-example-only online >online.log 2>&1 &
 pid=$!
 wait_for_log online.log '8080' || { cat online.log; fail "online example did not listen on 8080."; }
 kill -INT "$pid" 2>/dev/null || true

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -362,7 +362,12 @@ func (r *RedisIndex) getRequestKeys(ctx context.Context, engineKey BlockHash) ([
 
 // GetRequestKey returns the last request key (highest score) associated with the given engineKey.
 func (r *RedisIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error) {
-	vals, err := r.RedisClient.ZRevRange(ctx, redisEngineKey(engineKey), 0, 0).Result()
+	vals, err := r.RedisClient.ZRangeArgs(ctx, redis.ZRangeArgs{
+		Key:   redisEngineKey(engineKey),
+		Start: 0,
+		Stop:  0,
+		Rev:   true,
+	}).Result()
 	if err != nil {
 		return EmptyBlockHash, err
 	}

--- a/pkg/kvcache/kvblock/traced_index_test.go
+++ b/pkg/kvcache/kvblock/traced_index_test.go
@@ -152,7 +152,9 @@ func TestTracedIndexAddAndEvictSpansRecordErrors(t *testing.T) {
 	err := tracedIdx.Add(ctx, nil, []kvblock.BlockHash{1}, []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}})
 	require.ErrorIs(t, err, expectedErr)
 
-	err = tracedIdx.Evict(ctx, kvblock.BlockHash(1), kvblock.RequestKey, []kvblock.PodEntry{{PodIdentifier: "pod1", DeviceTier: "gpu"}})
+	err = tracedIdx.Evict(ctx, kvblock.BlockHash(1), kvblock.RequestKey, []kvblock.PodEntry{
+		{PodIdentifier: "pod1", DeviceTier: "gpu"},
+	})
 	require.ErrorIs(t, err, expectedErr)
 
 	spans := spanRecorder.Ended()

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -18,13 +18,19 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"strconv"
 	"strings"
 	"sync"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-kv-cache/pkg/telemetry"
 	"github.com/llm-d/llm-d-kv-cache/pkg/utils/logging"
 )
 
@@ -196,12 +202,30 @@ func (p *Pool) worker(ctx context.Context, workerIndex int) {
 // processRawMessage decodes the raw message payload using the adapter and processes the resulting event batch.
 func (p *Pool) processRawMessage(ctx context.Context, msg *RawMessage) {
 	logger := log.FromContext(ctx)
+	tracer := otel.Tracer(telemetry.InstrumentationName)
+	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.kvevents.process",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("llm_d.kv_cache.kvevents.topic", msg.Topic),
+		attribute.String("llm_d.kv_cache.kvevents.sequence", strconv.FormatUint(msg.Sequence, 10)),
+		attribute.Int("llm_d.kv_cache.kvevents.payload_size", len(msg.Payload)),
+	)
 
 	podID, modelName, batch, err := p.adapter.ParseMessage(msg)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		logger.Error(err, "Failed to parse message")
 		return
 	}
+
+	span.SetAttributes(
+		attribute.String("llm_d.kv_cache.kvevents.pod_identifier", podID),
+		attribute.String("llm_d.kv_cache.kvevents.model_name", modelName),
+		attribute.Int("llm_d.kv_cache.kvevents.event_count", len(batch.Events)),
+	)
 
 	p.processEventBatch(ctx, &batch, podID, modelName)
 }

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -146,6 +146,7 @@ type fakeAdapter struct {
 	err       error
 }
 
+//nolint:gocritic // unnamedResult: fake adapter mirrors EngineAdapter signature.
 func (f *fakeAdapter) ParseMessage(*RawMessage) (string, string, EventBatch, error) {
 	if f.err != nil {
 		return "", "", EventBatch{}, f.err

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -2,10 +2,16 @@ package kvevents //nolint:testpackage // tests use unexported processEventBatch
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-kv-cache/pkg/utils/logging"
@@ -50,6 +56,106 @@ func makeEngineKeys(n int, base uint64) []uint64 {
 		keys[i] = base + uint64(i) // #nosec G115 -- test data, i is small
 	}
 	return keys
+}
+
+func TestProcessRawMessageEmitsSpan(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	spanRecorder := setupSpanRecorder(t)
+	adapter := &fakeAdapter{
+		podID:     "pod-a",
+		modelName: "test-model",
+		batch: EventBatch{
+			Events: []GenericEvent{
+				&AllBlocksClearedEvent{},
+			},
+		},
+	}
+	pool := NewPool(DefaultConfig(), nil, nil, adapter)
+	msg := &RawMessage{
+		Topic:    "kv@pod-a@test-model",
+		Sequence: 42,
+		Payload:  []byte("payload"),
+	}
+
+	pool.processRawMessage(ctx, msg)
+
+	span := spanByName(t, spanRecorder.Ended(), "llm_d.kv_cache.kvevents.process")
+	attrs := spanAttributes(span)
+	require.Equal(t, "kv@pod-a@test-model", attrs["llm_d.kv_cache.kvevents.topic"].AsString())
+	require.Equal(t, "42", attrs["llm_d.kv_cache.kvevents.sequence"].AsString())
+	require.Equal(t, int64(7), attrs["llm_d.kv_cache.kvevents.payload_size"].AsInt64())
+	require.Equal(t, "pod-a", attrs["llm_d.kv_cache.kvevents.pod_identifier"].AsString())
+	require.Equal(t, "test-model", attrs["llm_d.kv_cache.kvevents.model_name"].AsString())
+	require.Equal(t, int64(1), attrs["llm_d.kv_cache.kvevents.event_count"].AsInt64())
+}
+
+func TestProcessRawMessageSpanRecordsParseError(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	spanRecorder := setupSpanRecorder(t)
+	expectedErr := errors.New("decode failed")
+	pool := NewPool(DefaultConfig(), nil, nil, &fakeAdapter{err: expectedErr})
+
+	pool.processRawMessage(ctx, &RawMessage{Topic: "bad-topic", Sequence: 7, Payload: []byte("bad")})
+
+	span := spanByName(t, spanRecorder.Ended(), "llm_d.kv_cache.kvevents.process")
+	require.Equal(t, codes.Error, span.Status().Code)
+	require.Equal(t, expectedErr.Error(), span.Status().Description)
+}
+
+func setupSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	return spanRecorder
+}
+
+func spanByName(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	for _, span := range spans {
+		if span.Name() == name {
+			return span
+		}
+	}
+
+	require.Failf(t, "missing span", "span %q not found", name)
+	return nil
+}
+
+func spanAttributes(span sdktrace.ReadOnlySpan) map[string]attribute.Value {
+	attrs := make(map[string]attribute.Value)
+	for _, attr := range span.Attributes() {
+		attrs[string(attr.Key)] = attr.Value
+	}
+	return attrs
+}
+
+type fakeAdapter struct {
+	podID     string
+	modelName string
+	batch     EventBatch
+	err       error
+}
+
+func (f *fakeAdapter) ParseMessage(*RawMessage) (string, string, EventBatch, error) {
+	if f.err != nil {
+		return "", "", EventBatch{}, f.err
+	}
+
+	return f.podID, f.modelName, f.batch, nil
+}
+
+func (f *fakeAdapter) ShardingKey(*RawMessage) string {
+	return f.podID
 }
 
 // TestCanonicalWritePath_FallbackLegacy verifies that when BlockSize equals

--- a/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_suite_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/go-logr/logr/testr"
+	"github.com/moby/moby/api/types/container"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"


### PR DESCRIPTION
## Summary

- Add an internal OpenTelemetry span around kvevents raw-message processing.
- Record transport attributes before parsing, then pod/model/event-count attributes after parsing.
- Mark parse failures with OTel error status.
- Add unit tests for span attributes and parse-error status.
- Fix the UDS e2e `HostConfig` import to match the current `testcontainers-go` Moby API and keep repo lint green.

Fixes #639
Refs #617

## Testing

- `go test ./pkg/kvevents`
- `go test ./pkg/...`
- `go test ./tests/e2e/uds_tokenizer -run '^$'`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./tests/e2e/uds_tokenizer`