### PR TITLE
feat(telemetry): standardize OTel instrumentation scope and span names

### DIFF
--- a/pkg/kvcache/constants.go
+++ b/pkg/kvcache/constants.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvcache
+
+// TracerScope is the OpenTelemetry instrumentation scope name for the kvcache package.
+const TracerScope = "llm-d-kv-cache/pkg/kvcache"

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -242,8 +242,8 @@ func (k *Indexer) ScoreTokens(
 	podIdentifiers []string,
 	extraFeatures []*kvblock.BlockExtraFeatures,
 ) (map[string]float64, error) {
-	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache")
-	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.score_tokens",
+	tracer := telemetry.Tracer(TracerScope)
+	ctx, span := tracer.Start(ctx, "score_tokens",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()

--- a/pkg/kvcache/kvblock/constants.go
+++ b/pkg/kvcache/kvblock/constants.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+// TracerScope is the OpenTelemetry instrumentation scope name for the kvblock package.
+const TracerScope = "llm-d-kv-cache/pkg/kvcache/kvblock"

--- a/pkg/kvcache/kvblock/traced_index.go
+++ b/pkg/kvcache/kvblock/traced_index.go
@@ -36,8 +36,8 @@ func NewTracedIndex(next Index) Index {
 }
 
 func (t *tracedIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHash, entries []PodEntry) error {
-	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache/kvblock")
-	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.index.add",
+	tracer := telemetry.Tracer(TracerScope)
+	ctx, span := tracer.Start(ctx, "index_add",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
@@ -59,8 +59,8 @@ func (t *tracedIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHa
 }
 
 func (t *tracedIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType, entries []PodEntry) error {
-	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache/kvblock")
-	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.index.evict",
+	tracer := telemetry.Tracer(TracerScope)
+	ctx, span := tracer.Start(ctx, "index_evict",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
@@ -85,8 +85,8 @@ func (t *tracedIndex) Lookup(
 	requestKeys []BlockHash,
 	podIdentifierSet sets.Set[string],
 ) (map[BlockHash][]PodEntry, error) {
-	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache/kvblock")
-	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.index",
+	tracer := telemetry.Tracer(TracerScope)
+	ctx, span := tracer.Start(ctx, "index_lookup",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()

--- a/pkg/kvcache/kvblock/traced_index_test.go
+++ b/pkg/kvcache/kvblock/traced_index_test.go
@@ -128,14 +128,14 @@ func TestTracedIndexAddAndEvictSpans(t *testing.T) {
 	require.NoError(t, err)
 
 	spans := spanRecorder.Ended()
-	addSpan := spanByName(t, spans, "llm_d.kv_cache.index.add")
+	addSpan := spanByName(t, spans, "index_add")
 	addAttrs := spanAttributes(addSpan)
 	require.Equal(t, int64(1), addAttrs["llm_d.kv_cache.index.add.engine_key_count"].AsInt64())
 	require.Equal(t, int64(1), addAttrs["llm_d.kv_cache.index.add.request_key_count"].AsInt64())
 	require.Equal(t, int64(2), addAttrs["llm_d.kv_cache.index.add.pod_entry_count"].AsInt64())
 	require.Equal(t, int64(2), addAttrs["llm_d.kv_cache.index.add.device_tier_count"].AsInt64())
 
-	evictSpan := spanByName(t, spans, "llm_d.kv_cache.index.evict")
+	evictSpan := spanByName(t, spans, "index_evict")
 	evictAttrs := spanAttributes(evictSpan)
 	require.Equal(t, "engine", evictAttrs["llm_d.kv_cache.index.evict.key_type"].AsString())
 	require.Equal(t, int64(1), evictAttrs["llm_d.kv_cache.index.evict.pod_entry_count"].AsInt64())
@@ -158,11 +158,11 @@ func TestTracedIndexAddAndEvictSpansRecordErrors(t *testing.T) {
 	require.ErrorIs(t, err, expectedErr)
 
 	spans := spanRecorder.Ended()
-	addSpan := spanByName(t, spans, "llm_d.kv_cache.index.add")
+	addSpan := spanByName(t, spans, "index_add")
 	require.Equal(t, codes.Error, addSpan.Status().Code)
 	require.Equal(t, expectedErr.Error(), addSpan.Status().Description)
 
-	evictSpan := spanByName(t, spans, "llm_d.kv_cache.index.evict")
+	evictSpan := spanByName(t, spans, "index_evict")
 	require.Equal(t, codes.Error, evictSpan.Status().Code)
 	require.Equal(t, expectedErr.Error(), evictSpan.Status().Description)
 }

--- a/pkg/kvcache/kvblock/traced_index_test.go
+++ b/pkg/kvcache/kvblock/traced_index_test.go
@@ -142,6 +142,77 @@ func TestTracedIndexAddAndEvictSpans(t *testing.T) {
 	require.Equal(t, int64(1), evictAttrs["llm_d.kv_cache.index.evict.device_tier_count"].AsInt64())
 }
 
+func TestTracedIndexLookupSpan(t *testing.T) {
+	ctx := context.Background()
+	spanRecorder := setupSpanRecorder(t)
+
+	baseIdx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+
+	tracedIdx := kvblock.NewTracedIndex(baseIdx)
+
+	engineKey := kvblock.BlockHash(123)
+	requestKey := kvblock.BlockHash(789)
+	entries := []kvblock.PodEntry{
+		{PodIdentifier: "pod1", DeviceTier: "gpu"},
+		{PodIdentifier: "pod2", DeviceTier: "cpu"},
+	}
+
+	err = tracedIdx.Add(ctx, []kvblock.BlockHash{engineKey}, []kvblock.BlockHash{requestKey}, entries)
+	require.NoError(t, err)
+
+	result, err := tracedIdx.Lookup(ctx, []kvblock.BlockHash{requestKey}, sets.Set[string]{})
+	require.NoError(t, err)
+	require.Len(t, result[requestKey], 2)
+
+	spans := spanRecorder.Ended()
+	lookupSpan := spanByName(t, spans, "index_lookup")
+	attrs := spanAttributes(lookupSpan)
+	require.Equal(t, int64(1), attrs["llm_d.kv_cache.index.lookup.block_count"].AsInt64())
+	require.Equal(t, int64(0), attrs["llm_d.kv_cache.lookup.pod_filter_count"].AsInt64())
+	require.Equal(t, true, attrs["llm_d.kv_cache.lookup.cache_hit"].AsBool())
+	require.Equal(t, int64(1), attrs["llm_d.kv_cache.lookup.blocks_found"].AsInt64())
+}
+
+func TestTracedIndexLookupSpanCacheMiss(t *testing.T) {
+	ctx := context.Background()
+	spanRecorder := setupSpanRecorder(t)
+
+	baseIdx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+
+	tracedIdx := kvblock.NewTracedIndex(baseIdx)
+
+	// Lookup a key that doesn't exist
+	nonExistentKey := kvblock.BlockHash(999)
+	result, err := tracedIdx.Lookup(ctx, []kvblock.BlockHash{nonExistentKey}, sets.Set[string]{})
+	require.NoError(t, err)
+	require.Len(t, result[nonExistentKey], 0)
+
+	spans := spanRecorder.Ended()
+	lookupSpan := spanByName(t, spans, "index_lookup")
+	attrs := spanAttributes(lookupSpan)
+	require.Equal(t, int64(1), attrs["llm_d.kv_cache.index.lookup.block_count"].AsInt64())
+	require.Equal(t, false, attrs["llm_d.kv_cache.lookup.cache_hit"].AsBool())
+	require.Equal(t, int64(0), attrs["llm_d.kv_cache.lookup.blocks_found"].AsInt64())
+}
+
+func TestTracedIndexLookupSpanRecordsError(t *testing.T) {
+	ctx := context.Background()
+	spanRecorder := setupSpanRecorder(t)
+
+	expectedErr := errors.New("lookup failed")
+	tracedIdx := kvblock.NewTracedIndex(&failingIndex{err: expectedErr})
+
+	_, err := tracedIdx.Lookup(ctx, []kvblock.BlockHash{1}, sets.Set[string]{})
+	require.ErrorIs(t, err, expectedErr)
+
+	spans := spanRecorder.Ended()
+	lookupSpan := spanByName(t, spans, "index_lookup")
+	require.Equal(t, codes.Error, lookupSpan.Status().Code)
+	require.Equal(t, expectedErr.Error(), lookupSpan.Status().Description)
+}
+
 func TestTracedIndexAddAndEvictSpansRecordErrors(t *testing.T) {
 	ctx := context.Background()
 	spanRecorder := setupSpanRecorder(t)

--- a/pkg/kvcache/traced_scorer.go
+++ b/pkg/kvcache/traced_scorer.go
@@ -46,8 +46,8 @@ func (t *tracedScorer) Score(
 	keys []kvblock.BlockHash,
 	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
 ) (map[string]float64, error) {
-	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache")
-	_, span := tracer.Start(ctx, "llm_d.kv_cache.scorer.compute",
+	tracer := telemetry.Tracer(TracerScope)
+	_, span := tracer.Start(ctx, "compute_scores",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()


### PR DESCRIPTION
## Summary

Align OpenTelemetry naming with [llm-d-router PR #1519](https://github.com/llm-d/llm-d-router/pull/1519) so operators can filter traces across kv-cache and router in a unified dashboard.

## Changes

| Dimension | Before | After |
|-----------|--------|-------|
| **Instrumentation scope** | `"llm-d-kv-cache"` (global constant) | Per-package Go paths: `"llm-d-kv-cache/pkg/kvcache"` and `"llm-d-kv-cache/pkg/kvcache/kvblock"` |
| **Span names** | `llm_d.kv_cache.score_tokens`, `llm_d.kv_cache.scorer.compute`, `llm_d.kv_cache.index.add`, `llm_d.kv_cache.index.evict`, `llm_d.kv_cache.index` | `score_tokens`, `compute_scores`, `index_add`, `index_evict`, `index_lookup` |
| **Attribute keys** | `llm_d.kv_cache.*` | **Unchanged** |

## Impact

- **Breaking for trace consumers**: Any dashboard, alert, or query filtering on the old span names or instrumentation scope names will need updating.
- `service.name` remains `llm-d-kv-cache` (no change).
- `pkg/telemetry/tracing.go` `InstrumentationName` constant retained for standalone mode.

## Files changed

- `pkg/kvcache/traced_scorer.go` — scope + span name
- `pkg/kvcache/indexer.go` — scope + span name
- `pkg/kvcache/kvblock/traced_index.go` — scope + 3 span names
- `pkg/kvcache/kvblock/traced_index_test.go` — updated test assertions

Fixes #651.