### PR TITLE
[WIP] feat: Add storage checkpoint index for KV offloads

### DIFF
--- a/examples/helper/events.go
+++ b/examples/helper/events.go
@@ -37,7 +37,7 @@ func SimulateProduceEvent(ctx context.Context, publisher *Publisher) error {
 	// Use enough tokens to fill 4 blocks (matching PromptHashes count) at blockSize=16.
 	tokenIds := make([]uint32, 64)
 	for i := range tokenIds {
-		tokenIds[i] = uint32(i + 1) //nolint:gosec // i is bounded by len(tokenIds)=64, no overflow
+		tokenIds[i] = uint32(i + 1)
 	}
 
 	// Create event in vLLM msgpack array format: [tag, hashes, parent, tokens, blockSize, loraID, medium, loraName]

--- a/examples/helper/events.go
+++ b/examples/helper/events.go
@@ -110,7 +110,11 @@ func SimulateRemoveEvent(ctx context.Context, publisher *Publisher) error {
 	return nil
 }
 
-func SetupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) (*kvevents.Pool, error) {
+func SetupEventsPool(
+	ctx context.Context,
+	kvBlockIndex kvblock.Index,
+	storageIndex kvblock.StorageIndex,
+) (*kvevents.Pool, error) {
 	logger := log.FromContext(ctx)
 
 	cfg := kvevents.DefaultConfig()
@@ -128,6 +132,7 @@ func SetupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) (*kvevents
 	}
 
 	pool := kvevents.NewPool(cfg, kvBlockIndex, tokenProcessor, adapter)
+	pool.SetStorageIndex(storageIndex)
 
 	return pool, nil
 }

--- a/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
+++ b/examples/kv_cache_aware_scorer/kvcache_aware_scorer.go
@@ -118,6 +118,7 @@ func New(ctx context.Context, config PrecisePrefixCachePluginConfig) (*PrecisePr
 	}
 
 	pool := kvevents.NewPool(config.KVEventsConfig, kvCacheIndexer.KVBlockIndex(), tokenProcessor, adapter)
+	pool.SetStorageIndex(kvCacheIndexer.StorageIndex())
 	pool.Start(ctx)
 
 	subscribersManager := kvevents.NewSubscriberManager(pool)

--- a/examples/kv_cache_index_service/server/main.go
+++ b/examples/kv_cache_index_service/server/main.go
@@ -114,7 +114,7 @@ func setupIndexerService(ctx context.Context) (*IndexerService, error) {
 	}
 
 	// Setup events pool with ZMQ subscriber
-	eventsPool, err := helper.SetupEventsPool(ctx, indexer.KVBlockIndex())
+	eventsPool, err := helper.SetupEventsPool(ctx, indexer.KVBlockIndex(), indexer.StorageIndex())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create events pool: %w", err)
 	}

--- a/examples/kv_events/offline/main.go
+++ b/examples/kv_events/offline/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// Setup events pool with ZMQ subscriber
-	eventsPool, err := helper.SetupEventsPool(ctx, kvCacheIndexer.KVBlockIndex())
+	eventsPool, err := helper.SetupEventsPool(ctx, kvCacheIndexer.KVBlockIndex(), kvCacheIndexer.StorageIndex())
 	if err != nil {
 		logger.Error(err, "failed to setup events pool")
 		return

--- a/examples/kv_events/online/main.go
+++ b/examples/kv_events/online/main.go
@@ -99,7 +99,7 @@ func run(ctx context.Context) error {
 	}
 
 	// Setup events pool
-	eventsPool, err := setupEventsPool(ctx, kvCacheIndexer.KVBlockIndex())
+	eventsPool, err := setupEventsPool(ctx, kvCacheIndexer)
 	if err != nil {
 		return err
 	}
@@ -213,7 +213,7 @@ func setupKVCacheIndexer(ctx context.Context) (*kvcache.Indexer, error) {
 	return kvCacheIndexer, nil
 }
 
-func setupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) (*kvevents.Pool, error) {
+func setupEventsPool(ctx context.Context, kvCacheIndexer *kvcache.Indexer) (*kvevents.Pool, error) {
 	logger := log.FromContext(ctx)
 
 	cfg := getEventsPoolConfig()
@@ -228,7 +228,8 @@ func setupEventsPool(ctx context.Context, kvBlockIndex kvblock.Index) (*kvevents
 		return nil, err
 	}
 
-	pool := kvevents.NewPool(cfg, kvBlockIndex, tokenProcessor, adapter)
+	pool := kvevents.NewPool(cfg, kvCacheIndexer.KVBlockIndex(), tokenProcessor, adapter)
+	pool.SetStorageIndex(kvCacheIndexer.StorageIndex())
 
 	return pool, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.20.0
+	github.com/seiflotfy/cuckoofilter v0.0.0-20240715131351-a2f2c23f1771
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
@@ -47,6 +48,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/dgraph-io/ristretto/v2 v2.4.0 h1:I/w09yLjhdcVD2QV192UJcq8dPBaAJb9pOuM
 github.com/dgraph-io/ristretto/v2 v2.4.0/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 h1:BS21ZUJ/B5X2UVUbczfmdWH7GapPWAhxcMsDnjJTU1E=
+github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
@@ -188,6 +190,8 @@ github.com/redis/go-redis/v9 v9.20.0 h1:WnQYxLkgO2xiXTCJY0ldIiI8dNqCDlQAG+AtaH7a
 github.com/redis/go-redis/v9 v9.20.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/seiflotfy/cuckoofilter v0.0.0-20240715131351-a2f2c23f1771 h1:emzAzMZ1L9iaKCTxdy3Em8Wv4ChIAGnfiz18Cda70g4=
+github.com/seiflotfy/cuckoofilter v0.0.0-20240715131351-a2f2c23f1771/go.mod h1:bR6DqgcAl1zTcOX8/pE2Qkj9XO00eCNqmKb7lXP8EAg=
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
@@ -200,6 +204,7 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -327,6 +332,7 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWM
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -54,6 +54,7 @@ class StorageEventPublisher:
     def __init__(
         self,
         endpoint: str,
+        block_size: int = 0,
         model_name: str | None = None,
         sndhwm: int = DEFAULT_STORAGE_EVENTS_HWM,
         medium: StorageMedium = StorageMedium.SHARED_STORAGE,
@@ -74,6 +75,7 @@ class StorageEventPublisher:
 
         self._model_name = model_name
         self._medium = medium
+        self._block_size = block_size
         self._topic = (
             f"kv@{self._medium.value}@{self._model_name}" if self._model_name else None
         )
@@ -102,7 +104,7 @@ class StorageEventPublisher:
             hashes,  # [1] block_hashes (all hashes from this complete_store call)
             0,  # [2] parent_hash (unknown at storage tier)
             [],  # [3] token_ids (empty)
-            0,  # [4] block_size (unused)
+            self._block_size,  # [4] block_size
             None,  # [5] lora_id
             self._medium.value,  # [6] medium / device tier
         ]

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py
@@ -54,7 +54,7 @@ class StorageEventPublisher:
     def __init__(
         self,
         endpoint: str,
-        block_size: int = 0,
+        block_size: int,
         model_name: str | None = None,
         sndhwm: int = DEFAULT_STORAGE_EVENTS_HWM,
         medium: StorageMedium = StorageMedium.SHARED_STORAGE,
@@ -63,9 +63,10 @@ class StorageEventPublisher:
 
         Args:
             endpoint: ZMQ bind address (e.g. ``tcp://*:5559``).
+            block_size: Number of tokens represented by each storage checkpoint.
             model_name: Model identifier included in the topic string.
-            medium: Storage backend type embedded in the topic and each event.
             sndhwm: ZMQ send high-water mark.
+            medium: Storage backend type embedded in the topic and each event.
         """
         self._ctx = zmq.Context()
         self._socket = self._ctx.socket(zmq.PUB)

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -46,17 +46,16 @@ class SharedStorageOffloadingManager(OffloadingManager):
         event_publisher=None,
     ) -> None:
         self.file_mapper: FileMapper = file_mapper
-        block_size = (
-            file_mapper.fields["hash_block_size"]
-            * file_mapper.fields["gpu_blocks_per_file"]
-        )
-        self._event_publisher = (
-            event_publisher
-            if event_publisher is not None
-            else self._create_event_publisher(
+        if event_publisher is not None:
+            self._event_publisher = event_publisher
+        else:
+            block_size = (
+                file_mapper.fields["hash_block_size"]
+                * file_mapper.fields["gpu_blocks_per_file"]
+            )
+            self._event_publisher = self._create_event_publisher(
                 file_mapper.model_name, block_size, extra_config or {}
             )
-        )
 
     @staticmethod
     def _create_event_publisher(model_name: str, block_size: int, extra_config: dict):

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -46,16 +46,20 @@ class SharedStorageOffloadingManager(OffloadingManager):
         event_publisher=None,
     ) -> None:
         self.file_mapper: FileMapper = file_mapper
+        block_size = (
+            file_mapper.fields["hash_block_size"]
+            * file_mapper.fields["gpu_blocks_per_file"]
+        )
         self._event_publisher = (
             event_publisher
             if event_publisher is not None
             else self._create_event_publisher(
-                self.file_mapper.model_name, extra_config or {}
+                file_mapper.model_name, block_size, extra_config or {}
             )
         )
 
     @staticmethod
-    def _create_event_publisher(model_name: str, extra_config: dict):
+    def _create_event_publisher(model_name: str, block_size: int, extra_config: dict):
         """Create a StorageEventPublisher if events are enabled in *extra_config*."""
         if not extra_config.get("enable_events", False):
             return None
@@ -75,6 +79,7 @@ class SharedStorageOffloadingManager(OffloadingManager):
 
             return StorageEventPublisher(
                 endpoint=endpoint,
+                block_size=block_size,
                 model_name=model_name,
                 **kwargs,
             )

--- a/kv_connectors/llmd_fs_backend/tests/cpu/test_storage_events.py
+++ b/kv_connectors/llmd_fs_backend/tests/cpu/test_storage_events.py
@@ -222,7 +222,11 @@ def _publisher_with_fake_zmq(monkeypatch):
     ctx = FakeZMQContext()
     monkeypatch.setattr(event_publisher_module.zmq, "Context", lambda: ctx)
 
-    publisher = StorageEventPublisher("tcp://*:5559", "test-model", 100_000)
+    publisher = StorageEventPublisher(
+        endpoint="tcp://*:5559",
+        block_size=100_000,
+        model_name="test-model",
+    )
     return publisher, ctx
 
 
@@ -259,7 +263,7 @@ def test_storage_event_publisher_emits_go_compatible_three_frame_message(monkeyp
         [0xABCDEF0123456789, 7, 0x0102],
         0,
         [],
-        0,
+        100_000,
         None,
         "SHARED_STORAGE",
     ]
@@ -392,7 +396,7 @@ def test_publisher_without_model_name(monkeypatch):
     ctx = FakeZMQContext()
     monkeypatch.setattr(event_publisher_module.zmq, "Context", lambda: ctx)
 
-    publisher = StorageEventPublisher("tcp://*:5559")
+    publisher = StorageEventPublisher("tcp://*:5559", 0)
     assert publisher._topic is None
 
     # Without any topic: publish_blocks_stored is a no-op (no crash)

--- a/kv_connectors/pvc_evictor/processes/deleter.py
+++ b/kv_connectors/pvc_evictor/processes/deleter.py
@@ -249,6 +249,7 @@ def deleter_process(
 
             event_publisher = StorageEventPublisher(
                 endpoint=endpoint,
+                block_size=0,
                 medium=StorageMedium.SHARED_STORAGE,
             )
             logger.info(

--- a/pkg/kvcache/backend.go
+++ b/pkg/kvcache/backend.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package kvcache
 
+import "github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+
 type KVCacheBackendConfig struct {
 	// Name is the identifier for this medium (e.g., "gpu", "cpu", "disk")
 	Name string `json:"name"`
@@ -27,5 +29,6 @@ func DefaultKVCacheBackendConfig() []*KVCacheBackendConfig {
 	return []*KVCacheBackendConfig{
 		{Name: "gpu", Weight: 1.0},
 		{Name: "cpu", Weight: 0.8},
+		{Name: kvblock.SharedStorageBackendName, Weight: 0.3},
 	}
 }

--- a/pkg/kvcache/backend.go
+++ b/pkg/kvcache/backend.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package kvcache
 
-import "github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
-
 type KVCacheBackendConfig struct {
 	// Name is the identifier for this medium (e.g., "gpu", "cpu", "disk")
 	Name string `json:"name"`
@@ -29,6 +27,5 @@ func DefaultKVCacheBackendConfig() []*KVCacheBackendConfig {
 	return []*KVCacheBackendConfig{
 		{Name: "gpu", Weight: 1.0},
 		{Name: "cpu", Weight: 0.8},
-		{Name: kvblock.SharedStorageBackendName, Weight: 0.3},
 	}
 }

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -41,6 +41,10 @@ type Config struct {
 	KVBlockScorerConfig *KVBlockScorerConfig    // not exported
 	BackendConfigs      []*KVCacheBackendConfig `json:"kvCacheBackendConfigs"`
 
+	// StorageIndexConfig configures the shared-storage checkpoint index.
+	// Nil or Enabled=false disables storage scoring entirely.
+	StorageIndexConfig *kvblock.StorageIndexConfig `json:"storageIndexConfig,omitempty"`
+
 	// TokenizersPoolConfig configures the in-process tokenization pool.
 	// Leaving it nil disables the pool; the prompt-string entry points then
 	// return an error.
@@ -67,6 +71,7 @@ type Indexer struct {
 	tokenProcessor kvblock.TokenProcessor // turns tokens to kv block keys
 	kvBlockIndex   kvblock.Index          // looks up pods for block keys
 	kvBlockScorer  KVBlockScorer          // scores pods based on block hits
+	storageIndex   kvblock.StorageIndex   // shared-storage checkpoint membership
 
 	tokenizersPool TokenizersPool
 }
@@ -102,11 +107,17 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 	// When tracing is not configured, the tracer is a no-op implementation.
 	scorer = NewTracedScorer(scorer)
 
+	var storageIdx kvblock.StorageIndex
+	if config.StorageIndexConfig != nil && config.StorageIndexConfig.Enabled {
+		storageIdx = kvblock.NewCuckooStorageIndex(config.StorageIndexConfig.FilterCapacity)
+	}
+
 	indexer := &Indexer{
 		config:         config,
 		tokenProcessor: tokenProcessor,
 		kvBlockIndex:   kvBlockIndex,
 		kvBlockScorer:  scorer,
+		storageIndex:   storageIdx,
 	}
 
 	if config.TokenizersPoolConfig != nil {
@@ -132,6 +143,11 @@ func (k *Indexer) Run(ctx context.Context) {
 // KVBlockIndex returns the kvblock.Index used by the Indexer.
 func (k *Indexer) KVBlockIndex() kvblock.Index {
 	return k.kvBlockIndex
+}
+
+// StorageIndex returns the shared-storage checkpoint index, or nil if disabled.
+func (k *Indexer) StorageIndex() kvblock.StorageIndex {
+	return k.storageIndex
 }
 
 // ErrInternalTokenizationDisabled is returned by the deprecated prompt-string
@@ -299,7 +315,90 @@ func (k *Indexer) ScoreTokens(
 		return nil, fmt.Errorf("failed to query kvblock scorer: %w", err)
 	}
 
+	if k.storageIndex != nil {
+		stride := k.storageIndex.Stride()
+		var storageWeight float64
+		for _, bc := range k.config.BackendConfigs {
+			if bc.Name == kvblock.SharedStorageBackendName || bc.Name == kvblock.ObjectStoreBackendName {
+				storageWeight = bc.Weight
+				break
+			}
+		}
+		if stride > 0 && storageWeight > 0 && len(blockKeys) >= stride {
+			if podScores == nil {
+				podScores = make(map[string]float64)
+			}
+			k.extendWithStorageScores(blockKeys, keyToPods, podScores, stride, storageWeight)
+		}
+	}
+
 	return podScores, nil
+}
+
+func (k *Indexer) extendWithStorageScores(
+	blockKeys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+	podScores map[string]float64,
+	stride int,
+	storageWeight float64,
+) {
+	// Storage-only hits are intentionally invisible for now. Storage is global
+	// availability, not pod-local locality, so only pods with an existing
+	// local GPU/CPU prefix are extended by storage checkpoints.
+	localPrefixLengths := computeLocalPrefixLengths(blockKeys, keyToPods)
+
+	for podID, localLen := range localPrefixLengths {
+		firstCheckpoint := ((localLen/stride)+1)*stride - 1
+		if firstCheckpoint >= len(blockKeys) {
+			continue
+		}
+
+		for pos := firstCheckpoint; pos < len(blockKeys); pos += stride {
+			if !k.storageIndex.HasCheckpoint(blockKeys[pos]) {
+				break
+			}
+			segmentStart := pos - stride + 1
+			if segmentStart < localLen {
+				segmentStart = localLen
+			}
+			storageBlocks := pos + 1 - segmentStart
+			podScores[podID] += float64(storageBlocks) * storageWeight
+		}
+	}
+}
+
+func computeLocalPrefixLengths(
+	keys []kvblock.BlockHash,
+	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
+) map[string]int {
+	lengths := make(map[string]int)
+	active := make(map[string]struct{})
+
+	for i, key := range keys {
+		pods := keyToPods[key]
+		if len(pods) == 0 {
+			break
+		}
+		if i == 0 {
+			for _, p := range pods {
+				active[p.PodIdentifier] = struct{}{}
+				lengths[p.PodIdentifier] = 1
+			}
+		} else {
+			podSet := make(map[string]struct{})
+			for _, p := range pods {
+				podSet[p.PodIdentifier] = struct{}{}
+			}
+			for pod := range active {
+				if _, exists := podSet[pod]; exists {
+					lengths[pod] = i + 1
+				} else {
+					delete(active, pod)
+				}
+			}
+		}
+	}
+	return lengths
 }
 
 // podsPerKeyPrintHelper formats a map of keys to pod entries for printing.

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -42,7 +42,7 @@ type Config struct {
 	BackendConfigs      []*KVCacheBackendConfig `json:"kvCacheBackendConfigs"`
 
 	// StorageIndexConfig configures the shared-storage checkpoint index.
-	// Nil or Enabled=false disables storage scoring entirely.
+	// Nil or Enabled=false disables storage indexing entirely.
 	StorageIndexConfig *kvblock.StorageIndexConfig `json:"storageIndexConfig,omitempty"`
 
 	// TokenizersPoolConfig configures the in-process tokenization pool.
@@ -315,90 +315,7 @@ func (k *Indexer) ScoreTokens(
 		return nil, fmt.Errorf("failed to query kvblock scorer: %w", err)
 	}
 
-	if k.storageIndex != nil {
-		stride := k.storageIndex.Stride()
-		var storageWeight float64
-		for _, bc := range k.config.BackendConfigs {
-			if bc.Name == kvblock.SharedStorageBackendName || bc.Name == kvblock.ObjectStoreBackendName {
-				storageWeight = bc.Weight
-				break
-			}
-		}
-		if stride > 0 && storageWeight > 0 && len(blockKeys) >= stride {
-			if podScores == nil {
-				podScores = make(map[string]float64)
-			}
-			k.extendWithStorageScores(blockKeys, keyToPods, podScores, stride, storageWeight)
-		}
-	}
-
 	return podScores, nil
-}
-
-func (k *Indexer) extendWithStorageScores(
-	blockKeys []kvblock.BlockHash,
-	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
-	podScores map[string]float64,
-	stride int,
-	storageWeight float64,
-) {
-	// Storage-only hits are intentionally invisible for now. Storage is global
-	// availability, not pod-local locality, so only pods with an existing
-	// local GPU/CPU prefix are extended by storage checkpoints.
-	localPrefixLengths := computeLocalPrefixLengths(blockKeys, keyToPods)
-
-	for podID, localLen := range localPrefixLengths {
-		firstCheckpoint := ((localLen/stride)+1)*stride - 1
-		if firstCheckpoint >= len(blockKeys) {
-			continue
-		}
-
-		for pos := firstCheckpoint; pos < len(blockKeys); pos += stride {
-			if !k.storageIndex.HasCheckpoint(blockKeys[pos]) {
-				break
-			}
-			segmentStart := pos - stride + 1
-			if segmentStart < localLen {
-				segmentStart = localLen
-			}
-			storageBlocks := pos + 1 - segmentStart
-			podScores[podID] += float64(storageBlocks) * storageWeight
-		}
-	}
-}
-
-func computeLocalPrefixLengths(
-	keys []kvblock.BlockHash,
-	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
-) map[string]int {
-	lengths := make(map[string]int)
-	active := make(map[string]struct{})
-
-	for i, key := range keys {
-		pods := keyToPods[key]
-		if len(pods) == 0 {
-			break
-		}
-		if i == 0 {
-			for _, p := range pods {
-				active[p.PodIdentifier] = struct{}{}
-				lengths[p.PodIdentifier] = 1
-			}
-		} else {
-			podSet := make(map[string]struct{})
-			for _, p := range pods {
-				podSet[p.PodIdentifier] = struct{}{}
-			}
-			for pod := range active {
-				if _, exists := podSet[pod]; exists {
-					lengths[pod] = i + 1
-				} else {
-					delete(active, pod)
-				}
-			}
-		}
-	}
-	return lengths
 }
 
 // podsPerKeyPrintHelper formats a map of keys to pod entries for printing.

--- a/pkg/kvcache/indexer_test.go
+++ b/pkg/kvcache/indexer_test.go
@@ -94,6 +94,26 @@ func newTestIndexer(t *testing.T, tp kvblock.TokenProcessor, pool kvcache.Tokeni
 	return kvcache.NewIndexerForTest(tp, idx, scorer, pool)
 }
 
+func newStorageTestIndexer(t *testing.T, blockKeys []uint64) *kvcache.Indexer {
+	t.Helper()
+
+	cfg, err := kvcache.NewDefaultConfig()
+	require.NoError(t, err)
+	cfg.StorageIndexConfig = &kvblock.StorageIndexConfig{
+		Enabled:        true,
+		FilterCapacity: 1_000,
+	}
+
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	indexer, err := kvcache.NewKVCacheIndexer(ctx, cfg, &mockTokenProcessor{
+		blockKeys: u64ToBlockKeys(blockKeys),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, indexer.StorageIndex())
+
+	return indexer
+}
+
 // populateIndex inserts block-key -> pod entries into the index.
 func populateIndex(t *testing.T, idx kvblock.Index, entries map[kvblock.BlockHash][]kvblock.PodEntry) {
 	t.Helper()
@@ -283,6 +303,80 @@ func TestScoreTokens(t *testing.T) {
 			assertScores(t, &tt, scores, err)
 		})
 	}
+}
+
+func TestScoreTokens_ExtendsLocalPrefixWithStorageCheckpoints(t *testing.T) {
+	indexer := newStorageTestIndexer(t, []uint64{10, 20, 30, 40, 50, 60, 70, 80})
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+
+	populateIndex(t, indexer.KVBlockIndex(), map[kvblock.BlockHash][]kvblock.PodEntry{
+		10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+		20: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+	})
+
+	indexer.StorageIndex().SetStride(4)
+	require.True(t, indexer.StorageIndex().AddCheckpoint(40))
+	require.True(t, indexer.StorageIndex().AddCheckpoint(80))
+
+	scores, err := indexer.ScoreTokens(ctx, []uint32{1}, testModel, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, scores, 1)
+	assert.InDelta(t, 3.8, scores[testPodA], 0.0001)
+}
+
+func TestScoreTokens_DoesNotExposeStorageOnlyHits(t *testing.T) {
+	indexer := newStorageTestIndexer(t, []uint64{10, 20, 30, 40})
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+
+	indexer.StorageIndex().SetStride(4)
+	require.True(t, indexer.StorageIndex().AddCheckpoint(40))
+
+	scores, err := indexer.ScoreTokens(ctx, []uint32{1}, testModel, []string{testPodA}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, scores)
+}
+
+func TestScoreTokens_StorageScoringStopsAtMissingCheckpoint(t *testing.T) {
+	indexer := newStorageTestIndexer(t, []uint64{10, 20, 30, 40, 50, 60, 70, 80})
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+
+	populateIndex(t, indexer.KVBlockIndex(), map[kvblock.BlockHash][]kvblock.PodEntry{
+		10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+		20: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+	})
+
+	indexer.StorageIndex().SetStride(4)
+	require.True(t, indexer.StorageIndex().AddCheckpoint(80))
+
+	scores, err := indexer.ScoreTokens(ctx, []uint32{1}, testModel, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, scores, 1)
+	assert.InDelta(t, 2.0, scores[testPodA], 0.0001)
+}
+
+func TestScoreTokens_StorageScoringHonorsPodIdentifierFilter(t *testing.T) {
+	indexer := newStorageTestIndexer(t, []uint64{10, 20, 30, 40})
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+
+	populateIndex(t, indexer.KVBlockIndex(), map[kvblock.BlockHash][]kvblock.PodEntry{
+		10: {
+			{PodIdentifier: testPodA, DeviceTier: "gpu"},
+			{PodIdentifier: testPodB, DeviceTier: "gpu"},
+		},
+		20: {
+			{PodIdentifier: testPodA, DeviceTier: "gpu"},
+			{PodIdentifier: testPodB, DeviceTier: "gpu"},
+		},
+	})
+
+	indexer.StorageIndex().SetStride(4)
+	require.True(t, indexer.StorageIndex().AddCheckpoint(40))
+
+	scores, err := indexer.ScoreTokens(ctx, []uint32{1}, testModel, []string{testPodA}, nil)
+	require.NoError(t, err)
+	require.Len(t, scores, 1)
+	assert.InDelta(t, 2.6, scores[testPodA], 0.0001)
+	assert.NotContains(t, scores, testPodB)
 }
 
 // --- GetPodScores-specific tests --------------------------------------------

--- a/pkg/kvcache/indexer_test.go
+++ b/pkg/kvcache/indexer_test.go
@@ -305,7 +305,7 @@ func TestScoreTokens(t *testing.T) {
 	}
 }
 
-func TestScoreTokens_ExtendsLocalPrefixWithStorageCheckpoints(t *testing.T) {
+func TestScoreTokens_DoesNotScoreSharedStorageCheckpoints(t *testing.T) {
 	indexer := newStorageTestIndexer(t, []uint64{10, 20, 30, 40, 50, 60, 70, 80})
 	ctx := logging.NewTestLoggerIntoContext(context.Background())
 
@@ -321,7 +321,7 @@ func TestScoreTokens_ExtendsLocalPrefixWithStorageCheckpoints(t *testing.T) {
 	scores, err := indexer.ScoreTokens(ctx, []uint32{1}, testModel, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, scores, 1)
-	assert.InDelta(t, 3.8, scores[testPodA], 0.0001)
+	assert.InDelta(t, 2.0, scores[testPodA], 0.0001)
 }
 
 func TestScoreTokens_DoesNotExposeStorageOnlyHits(t *testing.T) {
@@ -336,25 +336,7 @@ func TestScoreTokens_DoesNotExposeStorageOnlyHits(t *testing.T) {
 	assert.Empty(t, scores)
 }
 
-func TestScoreTokens_StorageScoringStopsAtMissingCheckpoint(t *testing.T) {
-	indexer := newStorageTestIndexer(t, []uint64{10, 20, 30, 40, 50, 60, 70, 80})
-	ctx := logging.NewTestLoggerIntoContext(context.Background())
-
-	populateIndex(t, indexer.KVBlockIndex(), map[kvblock.BlockHash][]kvblock.PodEntry{
-		10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-		20: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
-	})
-
-	indexer.StorageIndex().SetStride(4)
-	require.True(t, indexer.StorageIndex().AddCheckpoint(80))
-
-	scores, err := indexer.ScoreTokens(ctx, []uint32{1}, testModel, nil, nil)
-	require.NoError(t, err)
-	require.Len(t, scores, 1)
-	assert.InDelta(t, 2.0, scores[testPodA], 0.0001)
-}
-
-func TestScoreTokens_StorageScoringHonorsPodIdentifierFilter(t *testing.T) {
+func TestScoreTokens_StorageIndexDoesNotBypassPodIdentifierFilter(t *testing.T) {
 	indexer := newStorageTestIndexer(t, []uint64{10, 20, 30, 40})
 	ctx := logging.NewTestLoggerIntoContext(context.Background())
 
@@ -375,7 +357,7 @@ func TestScoreTokens_StorageScoringHonorsPodIdentifierFilter(t *testing.T) {
 	scores, err := indexer.ScoreTokens(ctx, []uint32{1}, testModel, []string{testPodA}, nil)
 	require.NoError(t, err)
 	require.Len(t, scores, 1)
-	assert.InDelta(t, 2.6, scores[testPodA], 0.0001)
+	assert.InDelta(t, 2.0, scores[testPodA], 0.0001)
 	assert.NotContains(t, scores, testPodB)
 }
 

--- a/pkg/kvcache/kvblock/storage_index.go
+++ b/pkg/kvcache/kvblock/storage_index.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"encoding/binary"
+	"sync"
+
+	cuckoo "github.com/seiflotfy/cuckoofilter"
+)
+
+const (
+	defaultFilterCapacity uint = 10_000_000
+
+	// SharedStorageBackendName is the normalized device tier/backend name used
+	// for shared-storage KV blocks.
+	SharedStorageBackendName = "shared_storage"
+	// ObjectStoreBackendName is the normalized device tier name used for object
+	// store KV blocks.
+	ObjectStoreBackendName = "object_store"
+)
+
+// StorageIndexConfig holds the configuration for the storage checkpoint index.
+type StorageIndexConfig struct {
+	Enabled        bool `json:"enabled"`
+	FilterCapacity uint `json:"filterCapacity"`
+}
+
+// DefaultStorageIndexConfig returns a default configuration for the storage index.
+func DefaultStorageIndexConfig() *StorageIndexConfig {
+	return &StorageIndexConfig{
+		Enabled:        false,
+		FilterCapacity: defaultFilterCapacity,
+	}
+}
+
+// StorageIndex tracks sparse checkpoint hashes that exist on storage.
+// Unlike the GPU/CPU Index, checkpoints are global (no pod qualifier), and
+// block hashes are already canonical request-key checkpoints (no engine-key
+// resolution). Cuckoo-backed implementations are approximate: lookups may
+// return false positives, and deletion can be affected by fingerprint
+// collisions.
+type StorageIndex interface {
+	// AddCheckpoint returns true when the checkpoint is present after the call.
+	// It returns false only when the backing filter cannot insert it.
+	AddCheckpoint(requestKey BlockHash) bool
+	HasCheckpoint(requestKey BlockHash) bool
+	RemoveCheckpoint(requestKey BlockHash)
+	Clear()
+	SetStride(stride int)
+	Stride() int
+}
+
+type cuckooStorageIndex struct {
+	filter *cuckoo.Filter
+	mu     sync.RWMutex
+	stride int
+}
+
+// NewCuckooStorageIndex creates a new StorageIndex backed by a Cuckoo filter.
+func NewCuckooStorageIndex(capacity uint) StorageIndex {
+	if capacity == 0 {
+		capacity = defaultFilterCapacity
+	}
+	return &cuckooStorageIndex{
+		filter: cuckoo.NewFilter(capacity),
+	}
+}
+
+func checkpointKey(requestKey BlockHash) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, uint64(requestKey))
+	return buf
+}
+
+func (c *cuckooStorageIndex) AddCheckpoint(requestKey BlockHash) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := checkpointKey(requestKey)
+	if c.filter.Lookup(key) {
+		return true
+	}
+	return c.filter.Insert(key)
+}
+
+func (c *cuckooStorageIndex) HasCheckpoint(requestKey BlockHash) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.filter.Lookup(checkpointKey(requestKey))
+}
+
+func (c *cuckooStorageIndex) RemoveCheckpoint(requestKey BlockHash) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.filter.Delete(checkpointKey(requestKey))
+}
+
+func (c *cuckooStorageIndex) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.filter.Reset()
+}
+
+func (c *cuckooStorageIndex) SetStride(stride int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stride = stride
+}
+
+func (c *cuckooStorageIndex) Stride() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.stride
+}

--- a/pkg/kvcache/kvblock/storage_index_test.go
+++ b/pkg/kvcache/kvblock/storage_index_test.go
@@ -14,17 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kvblock
+package kvblock_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 )
 
 func TestCuckooStorageIndexCheckpointLifecycle(t *testing.T) {
-	index := NewCuckooStorageIndex(1_000)
+	index := kvblock.NewCuckooStorageIndex(1_000)
 
 	require.True(t, index.AddCheckpoint(123))
 	assert.True(t, index.HasCheckpoint(123))
@@ -39,7 +41,7 @@ func TestCuckooStorageIndexCheckpointLifecycle(t *testing.T) {
 }
 
 func TestCuckooStorageIndexStrideAndDefaultCapacity(t *testing.T) {
-	index := NewCuckooStorageIndex(0)
+	index := kvblock.NewCuckooStorageIndex(0)
 
 	assert.Equal(t, 0, index.Stride())
 	index.SetStride(8)

--- a/pkg/kvcache/kvblock/storage_index_test.go
+++ b/pkg/kvcache/kvblock/storage_index_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCuckooStorageIndexCheckpointLifecycle(t *testing.T) {
+	index := NewCuckooStorageIndex(1_000)
+
+	require.True(t, index.AddCheckpoint(123))
+	assert.True(t, index.HasCheckpoint(123))
+	require.True(t, index.AddCheckpoint(123), "duplicate insert should leave checkpoint present")
+
+	index.RemoveCheckpoint(123)
+	assert.False(t, index.HasCheckpoint(123))
+
+	require.True(t, index.AddCheckpoint(456))
+	index.Clear()
+	assert.False(t, index.HasCheckpoint(456))
+}
+
+func TestCuckooStorageIndexStrideAndDefaultCapacity(t *testing.T) {
+	index := NewCuckooStorageIndex(0)
+
+	assert.Equal(t, 0, index.Stride())
+	index.SetStride(8)
+	assert.Equal(t, 8, index.Stride())
+	require.True(t, index.AddCheckpoint(789))
+	assert.True(t, index.HasCheckpoint(789))
+}

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -112,8 +112,63 @@ type Pool struct {
 	// built from event fields absent from the Index.Evict signature (device
 	// tier, KV-cache group, DP rank) and a store must be counted only after
 	// Index.Add succeeds — both of which only the Pool observes.
-	dedup *eventDedupFilter
-	wg    sync.WaitGroup
+	dedup           *eventDedupFilter
+	wg              sync.WaitGroup
+	storageIndex    kvblock.StorageIndex
+	storageStrideMu sync.Mutex
+}
+
+// SetStorageIndex wires a shared-storage checkpoint index into the Pool.
+func (p *Pool) SetStorageIndex(idx kvblock.StorageIndex) {
+	p.storageIndex = idx
+}
+
+func isStorageTier(deviceTier string) bool {
+	switch deviceTier {
+	case kvblock.SharedStorageBackendName, kvblock.ObjectStoreBackendName:
+		return true
+	default:
+		return strings.Contains(deviceTier, "storage")
+	}
+}
+
+func (p *Pool) configureStorageStride(ctx context.Context, blockSize int, podIdentifier string) bool {
+	debugLogger := log.FromContext(ctx).V(logging.DEBUG)
+
+	if blockSize <= 0 {
+		debugLogger.Info("storage BlockStored event has no block size, skipping checkpoint indexing",
+			"podIdentifier", podIdentifier)
+		return false
+	}
+	if p.tokenProcessor == nil || p.tokenProcessor.BlockSize() <= 0 {
+		debugLogger.Info("storage BlockStored event cannot derive stride, skipping checkpoint indexing",
+			"podIdentifier", podIdentifier, "blockSize", blockSize)
+		return false
+	}
+
+	tokenBlockSize := p.tokenProcessor.BlockSize()
+	if blockSize%tokenBlockSize != 0 {
+		debugLogger.Info("storage BlockStored event block size is not divisible by canonical block size, skipping checkpoint indexing",
+			"podIdentifier", podIdentifier, "blockSize", blockSize, "canonicalBlockSize", tokenBlockSize)
+		return false
+	}
+
+	stride := blockSize / tokenBlockSize
+	p.storageStrideMu.Lock()
+	defer p.storageStrideMu.Unlock()
+
+	currentStride := p.storageIndex.Stride()
+	if currentStride == 0 {
+		p.storageIndex.SetStride(stride)
+		return true
+	}
+	if currentStride != stride {
+		debugLogger.Info("storage BlockStored event stride differs from configured storage stride, skipping checkpoint indexing",
+			"podIdentifier", podIdentifier, "blockSize", blockSize, "canonicalBlockSize", tokenBlockSize,
+			"stride", stride, "configuredStride", currentStride)
+		return false
+	}
+	return true
 }
 
 // NewPool creates a Pool with a sharded worker setup.
@@ -348,6 +403,27 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 				dataParallelRank: noDataParallelRank,
 			}
 
+			if isStorageTier(deviceTier) {
+				if p.storageIndex == nil {
+					// Storage indexing is opt-in. Storage-only hits are
+					// intentionally invisible for now, so storage events never
+					// fall through into normal token processing.
+					continue
+				}
+				if !p.configureStorageStride(ctx, ev.BlockSize, podIdentifier) {
+					continue
+				}
+				// Storage events carry canonical request-key checkpoints, so
+				// they bypass the engine-key to request-key resolution path.
+				for _, hash := range ev.BlockHashes {
+					if !p.storageIndex.AddCheckpoint(kvblock.BlockHash(hash)) {
+						debugLogger.Info("storage index full, checkpoint not inserted",
+							"blockHash", hash, "podIdentifier", podIdentifier)
+					}
+				}
+				continue
+			}
+
 			// Use LoRA name as model identifier if available, otherwise fall back to base model name.
 			effectiveModelName := modelName
 			if ev.LoraName != nil && *ev.LoraName != "" {
@@ -461,6 +537,18 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 
 		case *BlockRemovedEvent:
 			deviceTier := normalizeDeviceTier(ev.DeviceTier)
+
+			if isStorageTier(deviceTier) {
+				if p.storageIndex == nil {
+					// Storage indexing is opt-in; when disabled, storage
+					// removal events must not evict normal GPU/CPU entries.
+					continue
+				}
+				for _, hash := range ev.BlockHashes {
+					p.storageIndex.RemoveCheckpoint(kvblock.BlockHash(hash))
+				}
+				continue
+			}
 
 			// Create PodEntry for this specific event's device tier.
 			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -2,6 +2,7 @@ package kvevents //nolint:testpackage // tests use unexported processEventBatch
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,6 +14,54 @@ import (
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/metrics"
 	"github.com/llm-d/llm-d-kv-cache/pkg/utils/logging"
 )
+
+type exactStorageIndex struct {
+	mu          sync.RWMutex
+	checkpoints map[kvblock.BlockHash]struct{}
+	stride      int
+}
+
+func newExactStorageIndex() *exactStorageIndex {
+	return &exactStorageIndex{checkpoints: make(map[kvblock.BlockHash]struct{})}
+}
+
+func (e *exactStorageIndex) AddCheckpoint(requestKey kvblock.BlockHash) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.checkpoints[requestKey] = struct{}{}
+	return true
+}
+
+func (e *exactStorageIndex) HasCheckpoint(requestKey kvblock.BlockHash) bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	_, ok := e.checkpoints[requestKey]
+	return ok
+}
+
+func (e *exactStorageIndex) RemoveCheckpoint(requestKey kvblock.BlockHash) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.checkpoints, requestKey)
+}
+
+func (e *exactStorageIndex) Clear() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	clear(e.checkpoints)
+}
+
+func (e *exactStorageIndex) SetStride(stride int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stride = stride
+}
+
+func (e *exactStorageIndex) Stride() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.stride
+}
 
 // newTestPool creates a Pool with real InMemoryIndex and
 // ChunkedTokenDatabase. blockSize (blockSizeTokens) is the canonical block size used by the
@@ -1104,4 +1153,212 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 	var m dto.Metric
 	require.NoError(t, c.Write(&m))
 	return m.GetCounter().GetValue()
+}
+func TestStorageBlockStoredIndexesCheckpointsAndStride(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, _, _ := newTestPool(t, 16)
+	storageIndex := kvblock.NewCuckooStorageIndex(1_000)
+	pool.SetStorageIndex(storageIndex)
+
+	batch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{40, 80},
+				BlockSize:   64,
+				DeviceTier:  "SHARED_STORAGE",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, batch, "pod-storage", "test-model")
+
+	assert.Equal(t, 4, storageIndex.Stride())
+	assert.True(t, storageIndex.HasCheckpoint(40))
+	assert.True(t, storageIndex.HasCheckpoint(80))
+}
+
+func TestStorageBlockStoredNoopsWhenStorageIndexDisabled(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 16)
+	tokens := makeTokens(16)
+
+	batch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{40},
+				Tokens:      tokens,
+				BlockSize:   16,
+				DeviceTier:  "SHARED_STORAGE",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, batch, "pod-storage", "test-model")
+
+	canonicalKeys, err := tp.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, canonicalKeys, 1)
+	result, err := idx.Lookup(ctx, canonicalKeys, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result[canonicalKeys[0]])
+
+	_, err = idx.GetRequestKey(ctx, kvblock.BlockHash(40))
+	assert.Error(t, err)
+}
+
+func TestStorageBlockRemovedDeletesCheckpoints(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, _, _ := newTestPool(t, 16)
+	storageIndex := kvblock.NewCuckooStorageIndex(1_000)
+	pool.SetStorageIndex(storageIndex)
+	require.True(t, storageIndex.AddCheckpoint(40))
+
+	batch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockRemovedEvent{
+				BlockHashes: []uint64{40},
+				DeviceTier:  "SHARED_STORAGE",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, batch, "pod-storage", "test-model")
+
+	assert.False(t, storageIndex.HasCheckpoint(40))
+}
+
+func TestStorageBlockRemovedNoopsWhenStorageIndexDisabled(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 16)
+	tokens := makeTokens(16)
+	engineKey := uint64(40)
+
+	storeBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{engineKey},
+				Tokens:      tokens,
+			},
+		},
+	}
+	pool.processEventBatch(ctx, storeBatch, "pod-a", "test-model")
+
+	removeBatch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockRemovedEvent{
+				BlockHashes: []uint64{engineKey},
+				DeviceTier:  "SHARED_STORAGE",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, removeBatch, "pod-a", "test-model")
+
+	canonicalKeys, err := tp.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, canonicalKeys, 1)
+	result, err := idx.Lookup(ctx, canonicalKeys, nil)
+	require.NoError(t, err)
+	require.Len(t, result[canonicalKeys[0]], 1)
+	assert.Equal(t, "pod-a", result[canonicalKeys[0]][0].PodIdentifier)
+	assert.Equal(t, "gpu", result[canonicalKeys[0]][0].DeviceTier)
+}
+
+func TestStorageBlockStoredSkipsInvalidBlockSize(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, _, _ := newTestPool(t, 16)
+	storageIndex := kvblock.NewCuckooStorageIndex(1_000)
+	pool.SetStorageIndex(storageIndex)
+
+	batch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{40},
+				BlockSize:   50,
+				DeviceTier:  "SHARED_STORAGE",
+			},
+		},
+	}
+	pool.processEventBatch(ctx, batch, "pod-storage", "test-model")
+
+	assert.Equal(t, 0, storageIndex.Stride())
+	assert.False(t, storageIndex.HasCheckpoint(40))
+}
+
+func TestStorageBlockStoredSkipsInconsistentStride(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, _, _ := newTestPool(t, 16)
+	storageIndex := kvblock.NewCuckooStorageIndex(1_000)
+	pool.SetStorageIndex(storageIndex)
+
+	pool.processEventBatch(ctx, &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{40},
+				BlockSize:   64,
+				DeviceTier:  "SHARED_STORAGE",
+			},
+		},
+	}, "pod-storage", "test-model")
+	pool.processEventBatch(ctx, &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{20},
+				BlockSize:   32,
+				DeviceTier:  "SHARED_STORAGE",
+			},
+		},
+	}, "pod-storage", "test-model")
+
+	assert.Equal(t, 4, storageIndex.Stride())
+	assert.True(t, storageIndex.HasCheckpoint(40))
+	assert.False(t, storageIndex.HasCheckpoint(20))
+}
+
+func TestStorageBlockStoredConcurrentStrideInitialization(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, _, _ := newTestPool(t, 16)
+	storageIndex := newExactStorageIndex()
+	pool.SetStorageIndex(storageIndex)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	batches := []*EventBatch{
+		{
+			Events: []GenericEvent{
+				&BlockStoredEvent{
+					BlockHashes: []uint64{40},
+					BlockSize:   64,
+					DeviceTier:  "SHARED_STORAGE",
+				},
+			},
+		},
+		{
+			Events: []GenericEvent{
+				&BlockStoredEvent{
+					BlockHashes: []uint64{20},
+					BlockSize:   32,
+					DeviceTier:  "SHARED_STORAGE",
+				},
+			},
+		},
+	}
+
+	for _, batch := range batches {
+		wg.Add(1)
+		go func(batch *EventBatch) {
+			defer wg.Done()
+			<-start
+			pool.processEventBatch(ctx, batch, "pod-storage", "test-model")
+		}(batch)
+	}
+	close(start)
+	wg.Wait()
+
+	switch storageIndex.Stride() {
+	case 4:
+		assert.True(t, storageIndex.HasCheckpoint(40))
+		assert.False(t, storageIndex.HasCheckpoint(20))
+	case 2:
+		assert.True(t, storageIndex.HasCheckpoint(20))
+		assert.False(t, storageIndex.HasCheckpoint(40))
+	default:
+		t.Fatalf("unexpected stride: %d", storageIndex.Stride())
+	}
 }


### PR DESCRIPTION
## Summary

Adds a write-path-only storage checkpoint index so the Go indexer can track which KV blocks exist on shared storage (FS backend). This is the foundation for storage-aware scoring, pre-fetch signals... and any work related to it.

**Python side:**
- `StorageEventPublisher` now requires a `block_size` parameter, populated from `hash_block_size * gpu_blocks_per_file` in the FS backend manager. This value is emitted in field `[4]` of `BlockStored` events so the Go side can derive stride at runtime without duplicated configuration.
- PVC evictor passes `block_size=0` explicitly (it only emits removal events).

**Go side:**
- New `StorageIndex` interface (`AddCheckpoint`, `HasCheckpoint`, `RemoveCheckpoint`, `Clear`, `SetStride`, `Stride`) backed by a Cuckoo filter in `pkg/kvcache/kvblock/storage_index.go`.
- `Indexer` creates and exposes the `StorageIndex` when `StorageIndexConfig.Enabled` is true.
- `Pool.processEventBatch()` detects storage-tier events via `isStorageTier()` and routes them to the storage index, bypassing the normal engine-key-to-request-key resolution path. Storage events carry canonical request-key checkpoints directly.
- Stride is learned from the first `BlockStored` event: `event.BlockSize / tokenProcessor.BlockSize()`. Thread-safe initialization via `storageStrideMu` mutex with consistency validation on subsequent events.
- Storage indexing is opt-in: when `storageIndex` is nil, storage events are silently dropped and never fall through into GPU/CPU processing.
- `SHARED_STORAGE` pod identifier is excluded from scoring to prevent it from appearing as a routable pod.

## Testing

Unit tests covered, now benchmarking for potential regressions (WIP).

## Related Issues

Closes #520 
