### PR TITLE
fix(kvcache): unify engine-to-request mapping and fix Redis scoring

### DIFF
--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -244,14 +244,8 @@ func (m *CostAwareMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys 
 	//   many:1 (4 eng, 1 req) -> E0->R0, E1->R0, E2->R0, E3->R0
 	//   1:many (1 eng, 4 req) -> E0->[R0, R1, R2, R3]
 	if engineKeys != nil {
-		newMappings := make(map[BlockHash][]BlockHash)
-		n := max(len(engineKeys), len(requestKeys))
-		for i := 0; i < n; i++ {
-			ek := engineKeys[i*len(engineKeys)/n]
-			rk := requestKeys[i*len(requestKeys)/n]
-			newMappings[ek] = append(newMappings[ek], rk)
-		}
-		for ek, rks := range newMappings {
+		mappings := engineToRequestMapping(engineKeys, requestKeys)
+		for ek, rks := range mappings {
 			m.requestKeys.Add(ek, rks)
 		}
 	}

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -167,14 +167,8 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 	//   many:1 (4 eng, 1 req) -> E0->R0, E1->R0, E2->R0, E3->R0
 	//   1:many (1 eng, 4 req) -> E0->[R0, R1, R2, R3]
 	if engineKeys != nil {
-		newMappings := make(map[BlockHash][]BlockHash)
-		n := max(len(engineKeys), len(requestKeys))
-		for i := 0; i < n; i++ {
-			ek := engineKeys[i*len(engineKeys)/n]
-			rk := requestKeys[i*len(requestKeys)/n]
-			newMappings[ek] = append(newMappings[ek], rk)
-		}
-		for ek, rks := range newMappings {
+		mappings := engineToRequestMapping(engineKeys, requestKeys)
+		for ek, rks := range mappings {
 			m.engineToRequestKeys.Add(ek, rks)
 		}
 	}

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -210,6 +210,9 @@ func (e *PodEntry) String() string {
 // positional scores (e.g. Redis ZAdd) can iterate the slice and use the index.
 func engineToRequestMapping(engineKeys, requestKeys []BlockHash) map[BlockHash][]BlockHash {
 	mappings := make(map[BlockHash][]BlockHash)
+	if len(engineKeys) == 0 || len(requestKeys) == 0 {
+		return mappings
+	}
 	n := max(len(engineKeys), len(requestKeys))
 	for i := 0; i < n; i++ {
 		ek := engineKeys[i*len(engineKeys)/n]

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -208,8 +208,9 @@ func (e *PodEntry) String() string {
 // proportional distribution based on the lengths of both slices.
 // Each engine key maps to an ordered slice of request keys; callers that need
 // positional scores (e.g. Redis ZAdd) can iterate the slice and use the index.
+// Returns an empty map if either slice is empty.
 func engineToRequestMapping(engineKeys, requestKeys []BlockHash) map[BlockHash][]BlockHash {
-	mappings := make(map[BlockHash][]BlockHash)
+	mappings := make(map[BlockHash][]BlockHash, len(engineKeys))
 	if len(engineKeys) == 0 || len(requestKeys) == 0 {
 		return mappings
 	}

--- a/pkg/kvcache/kvblock/index.go
+++ b/pkg/kvcache/kvblock/index.go
@@ -203,3 +203,18 @@ func (e *PodEntry) String() string {
 	}
 	return fmt.Sprintf("%s@%s%s", e.PodIdentifier, e.DeviceTier, suffix)
 }
+
+// engineToRequestMapping computes engine-key → request-key mappings using
+// proportional distribution based on the lengths of both slices.
+// Each engine key maps to an ordered slice of request keys; callers that need
+// positional scores (e.g. Redis ZAdd) can iterate the slice and use the index.
+func engineToRequestMapping(engineKeys, requestKeys []BlockHash) map[BlockHash][]BlockHash {
+	mappings := make(map[BlockHash][]BlockHash)
+	n := max(len(engineKeys), len(requestKeys))
+	for i := 0; i < n; i++ {
+		ek := engineKeys[i*len(engineKeys)/n]
+		rk := requestKeys[i*len(requestKeys)/n]
+		mappings[ek] = append(mappings[ek], rk)
+	}
+	return mappings
+}

--- a/pkg/kvcache/kvblock/index_internal_test.go
+++ b/pkg/kvcache/kvblock/index_internal_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEngineToRequestMapping_OneToOne(t *testing.T) {
+	engineKeys := []BlockHash{100, 200, 300, 400}
+	requestKeys := []BlockHash{1000, 2000, 3000, 4000}
+
+	mappings := engineToRequestMapping(engineKeys, requestKeys)
+
+	require.Len(t, mappings, 4)
+	for i, ek := range engineKeys {
+		rks, ok := mappings[ek]
+		require.True(t, ok, "engine key %d should be present", ek)
+		assert.Equal(t, []BlockHash{requestKeys[i]}, rks)
+	}
+}
+
+func TestEngineToRequestMapping_ManyToOne(t *testing.T) {
+	engineKeys := []BlockHash{10, 11, 12, 13}
+	requestKeys := []BlockHash{9000}
+
+	mappings := engineToRequestMapping(engineKeys, requestKeys)
+
+	require.Len(t, mappings, 4)
+	for _, ek := range engineKeys {
+		rks, ok := mappings[ek]
+		require.True(t, ok, "engine key %d should be present", ek)
+		assert.Equal(t, []BlockHash{9000}, rks, "each engine key should map to the single request key")
+	}
+}
+
+func TestEngineToRequestMapping_OneToMany(t *testing.T) {
+	engineKeys := []BlockHash{100}
+	requestKeys := []BlockHash{1000, 2000, 3000, 4000}
+
+	mappings := engineToRequestMapping(engineKeys, requestKeys)
+
+	require.Len(t, mappings, 1)
+	rks := mappings[BlockHash(100)]
+	assert.Equal(t, []BlockHash{1000, 2000, 3000, 4000}, rks,
+		"single engine key should map to all request keys in order")
+}
+
+func TestEngineToRequestMapping_EmptySlices(t *testing.T) {
+	mappings := engineToRequestMapping(nil, nil)
+	assert.Empty(t, mappings)
+
+	mappings = engineToRequestMapping([]BlockHash{}, []BlockHash{1})
+	assert.Empty(t, mappings)
+
+	mappings = engineToRequestMapping([]BlockHash{1}, []BlockHash{})
+	assert.Empty(t, mappings)
+}
+
+func TestEngineToRequestMapping_ScoreOrder(t *testing.T) {
+	engineKeys := []BlockHash{100}
+	requestKeys := []BlockHash{1000, 2000, 3000}
+
+	mappings := engineToRequestMapping(engineKeys, requestKeys)
+
+	rks := mappings[BlockHash(100)]
+	require.Len(t, rks, 3)
+	for j, rk := range rks {
+		assert.Equal(t, requestKeys[j], rk,
+			"relative index %d should correspond to requestKeys[%d]", j, j)
+	}
+}

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -255,11 +255,11 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 	//   many:1 (4 eng, 1 req) -> E0->R0, E1->R0, E2->R0, E3->R0
 	//   1:many (1 eng, 4 req) -> E0->[R0, R1, R2, R3]
 	if engineKeys != nil {
-		n := max(len(engineKeys), len(requestKeys))
-		for i := 0; i < n; i++ {
-			ek := engineKeys[i*len(engineKeys)/n]
-			rk := requestKeys[i*len(requestKeys)/n]
-			pipe.ZAdd(ctx, redisEngineKey(ek), redis.Z{Score: float64(i), Member: rk.String()})
+		mappings := engineToRequestMapping(engineKeys, requestKeys)
+		for ek, rks := range mappings {
+			for j, rk := range rks {
+				pipe.ZAdd(ctx, redisEngineKey(ek), redis.Z{Score: float64(j), Member: rk.String()})
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Extract duplicated engine→request key mapping logic from three Index implementations into a shared `engineToRequestMapping()` helper, and correct the Redis ZAdd score calculation to use per-mapping relative indices.

## Problem

`InMemoryIndex`, `CostAwareMemoryIndex`, and `RedisIndex` each contained identical 7-line proportional distribution logic for computing engine-to-request key mappings. Additionally, the Redis implementation used the global loop counter `i` as the ZAdd score instead of the relative index `j` within each engine's sorted set — semantically incorrect even though current mapping ratios produce equivalent results.

## Changes

- **pkg/kvcache/kvblock/index.go**: Add `engineToRequestMapping(engineKeys, requestKeys []BlockHash) map[BlockHash][]BlockHash` with defensive empty-slice guard
- **pkg/kvcache/kvblock/{in_memory,cost_aware_memory,redis}.go**: Replace inline mapping logic with calls to the shared helper
- **pkg/kvcache/kvblock/redis.go**: Use `j` (index within each mapping slice) instead of `i` (global loop counter) for ZAdd scores
- **pkg/kvcache/kvblock/index_internal_test.go**: Add unit tests covering 1:1, many:1, 1:many, empty slices, and score ordering

## Testing

- `go test ./pkg/kvcache/...` — all existing tests pass
- New `TestEngineToRequestMapping_*` tests cover all mapping scenarios and edge cases
