### PR TITLE
fix(kvblock): avoid full keyspace scan in Redis Clear

### DIFF
--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -272,6 +272,7 @@ func (r *RedisIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHas
 				return err
 			}
 			pipe.HSet(ctx, redisKey, field, "")
+			pipe.SAdd(ctx, redisPodEntriesKey(entry.PodIdentifier), redisPodEntryMember(redisKey, field))
 		}
 	}
 
@@ -330,6 +331,7 @@ func (r *RedisIndex) evictPodsFromRequestKey(ctx context.Context, requestKey Blo
 			return err
 		}
 		pipe.HDel(ctx, redisKey, field)
+		pipe.SRem(ctx, redisPodEntriesKey(entry.PodIdentifier), redisPodEntryMember(redisKey, field))
 	}
 
 	if _, err := pipe.Exec(ctx); err != nil {
@@ -408,60 +410,79 @@ func redisEngineKey(engineKey BlockHash) string {
 	return "engine:" + engineKey.String()
 }
 
-// Clear removes every hash field for the pod across all request-key hashes and
-// device tiers. Each field is a JSON-encoded PodEntry, so matching decodes the
-// field and compares PodIdentifier — catching every tier, group, and speculative
-// variant. It pages the keyspace with SCAN (skipping engine: keys), HDELs the
-// pod's fields, and prunes now-empty hashes. O(keyspace), but Clear is rare and
-// off the Lookup/Add hot path. Because it deletes from the shared store, it is
-// correct for multi-replica deployments with no cross-process coordination.
+func redisPodEntriesKey(podIdentifier string) string {
+	return "kvblock:pod:" + podIdentifier + ":entries"
+}
+
+func redisPodEntryMember(requestKey, field string) string {
+	return requestKey + "\x00" + field
+}
+
+type redisPodEntryRef struct {
+	requestKey string
+	field      string
+}
+
+func parseRedisPodEntryMember(member string) (redisPodEntryRef, bool) {
+	requestKey, field, ok := strings.Cut(member, "\x00")
+	if !ok || requestKey == "" || field == "" {
+		return redisPodEntryRef{}, false
+	}
+	return redisPodEntryRef{requestKey: requestKey, field: field}, true
+}
+
+// Clear removes every reverse-indexed field for the pod across all request-key
+// hashes and device tiers. Add maintains an exact per-pod set of
+// "<requestKey>\x00<encodedPodField>" entries, so Clear only touches keys this
+// index recorded for that pod instead of scanning the whole Redis keyspace.
 func (r *RedisIndex) Clear(ctx context.Context, podIdentifier string) error {
 	logger := log.FromContext(ctx).WithName("kvblock.RedisIndex.Clear")
+	podEntriesKey := redisPodEntriesKey(podIdentifier)
 
 	const scanBatch int64 = 1024
-	removed := 0
+	processed := 0
 	var cursor uint64
 	for {
-		keys, next, err := r.RedisClient.Scan(ctx, cursor, "*", scanBatch).Result()
+		members, next, err := r.RedisClient.SScan(ctx, podEntriesKey, cursor, "", scanBatch).Result()
 		if err != nil {
-			return fmt.Errorf("clear scan failed: %w", err)
+			return fmt.Errorf("clear reverse-index scan failed: %w", err)
 		}
-		for _, key := range keys {
-			if strings.HasPrefix(key, "engine:") {
-				continue // engine:<hash> ZSETs hold no pod fields
-			}
-
-			fields, err := r.RedisClient.HKeys(ctx, key).Result()
-			if err != nil {
-				return fmt.Errorf("clear hkeys failed for %s: %w", key, err)
-			}
-
-			var stale []string
-			for _, field := range fields {
-				if entry, ok := decodeRedisPodField(field); ok && entry.PodIdentifier == podIdentifier {
-					stale = append(stale, field)
-				}
-			}
-			if len(stale) == 0 {
-				continue
-			}
-
-			if err := r.RedisClient.HDel(ctx, key, stale...).Err(); err != nil {
-				return fmt.Errorf("clear hdel failed for %s: %w", key, err)
-			}
-			removed += len(stale)
-
-			if err := pruneRequestKeyScript.Run(ctx, r.RedisClient, []string{key}).Err(); err != nil &&
-				!errors.Is(err, redis.Nil) {
-				return fmt.Errorf("clear prune failed for %s: %w", key, err)
-			}
+		if err := r.clearRedisPodEntryMembers(ctx, podEntriesKey, members); err != nil {
+			return err
 		}
+		processed += len(members)
 
-		if cursor = next; cursor == 0 {
+		if cursor = next; cursor != 0 {
+			continue
+		}
+		remaining, err := r.RedisClient.SCard(ctx, podEntriesKey).Result()
+		if err != nil {
+			return fmt.Errorf("clear reverse-index cardinality failed: %w", err)
+		}
+		if remaining == 0 {
 			break
 		}
 	}
 
-	logger.Info("cleared pod from index", "pod", podIdentifier, "removed", removed)
+	logger.Info("cleared pod from index", "pod", podIdentifier, "members", processed)
+	return nil
+}
+
+func (r *RedisIndex) clearRedisPodEntryMembers(ctx context.Context, podEntriesKey string, members []string) error {
+	if len(members) == 0 {
+		return nil
+	}
+
+	pipe := r.RedisClient.Pipeline()
+	for _, member := range members {
+		ref, ok := parseRedisPodEntryMember(member)
+		if ok {
+			pipe.HDel(ctx, ref.requestKey, ref.field)
+		}
+		pipe.SRem(ctx, podEntriesKey, member)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("clear reverse-index pipeline failed: %w", err)
+	}
 	return nil
 }

--- a/pkg/kvcache/kvblock/redis_test.go
+++ b/pkg/kvcache/kvblock/redis_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kvblock_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -27,6 +28,11 @@ import (
 
 // createRedisIndexForTesting creates a new RedisIndex with a mock Redis server for testing.
 func createRedisIndexForTesting(t *testing.T) Index {
+	t.Helper()
+	return createRedisIndexForInspection(t)
+}
+
+func createRedisIndexForInspection(t *testing.T) *RedisIndex {
 	t.Helper()
 	server, err := miniredis.Run()
 	require.NoError(t, err)
@@ -41,10 +47,81 @@ func createRedisIndexForTesting(t *testing.T) Index {
 	}
 	index, err := NewRedisIndex(redisConfig)
 	require.NoError(t, err)
-	return index
+	redisIndex, ok := index.(*RedisIndex)
+	require.True(t, ok)
+	return redisIndex
 }
 
 // TestRedisIndexBehavior tests the Redis index implementation using common test behaviors.
 func TestRedisIndexBehavior(t *testing.T) {
 	testCommonIndexBehavior(t, createRedisIndexForTesting)
+}
+
+func TestRedisClearPreservesUnrelatedKeys(t *testing.T) {
+	index := createRedisIndexForInspection(t)
+	ctx := t.Context()
+	pod := PodEntry{PodIdentifier: "pod-clear", DeviceTier: "gpu"}
+	requestKey := BlockHash(0xC1EA1001)
+	unrelatedField := redisTestPodField(t, pod)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{requestKey}, []PodEntry{pod}))
+	require.NoError(t, index.RedisClient.HSet(ctx, "unrelated-hash", unrelatedField, "keep").Err())
+	require.NoError(t, index.RedisClient.Set(ctx, "unrelated-string", "keep", 0).Err())
+
+	require.NoError(t, index.Clear(ctx, pod.PodIdentifier))
+
+	gotHash, err := index.RedisClient.HGet(ctx, "unrelated-hash", unrelatedField).Result()
+	require.NoError(t, err)
+	require.Equal(t, "keep", gotHash)
+
+	gotString, err := index.RedisClient.Get(ctx, "unrelated-string").Result()
+	require.NoError(t, err)
+	require.Equal(t, "keep", gotString)
+
+	hits, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	require.Empty(t, hits[requestKey])
+
+	exists, err := index.RedisClient.Exists(ctx, requestKey.String()).Result()
+	require.NoError(t, err)
+	require.Zero(t, exists)
+}
+
+func TestRedisEvictPrunesReverseIndex(t *testing.T) {
+	index := createRedisIndexForInspection(t)
+	ctx := t.Context()
+	pod := PodEntry{PodIdentifier: "pod-evict", DeviceTier: "gpu"}
+	requestKey := BlockHash(0xC1EA1002)
+	podEntriesKey := "kvblock:pod:" + pod.PodIdentifier + ":entries"
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{requestKey}, []PodEntry{pod}))
+	count, err := index.RedisClient.SCard(ctx, podEntriesKey).Result()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+
+	require.NoError(t, index.Evict(ctx, requestKey, RequestKey, []PodEntry{pod}))
+
+	count, err = index.RedisClient.SCard(ctx, podEntriesKey).Result()
+	require.NoError(t, err)
+	require.Zero(t, count)
+}
+
+func TestRedisClearDropsMalformedReverseEntry(t *testing.T) {
+	index := createRedisIndexForInspection(t)
+	ctx := t.Context()
+	podEntriesKey := "kvblock:pod:pod-malformed:entries"
+
+	require.NoError(t, index.RedisClient.SAdd(ctx, podEntriesKey, "malformed").Err())
+	require.NoError(t, index.Clear(ctx, "pod-malformed"))
+
+	count, err := index.RedisClient.SCard(ctx, podEntriesKey).Result()
+	require.NoError(t, err)
+	require.Zero(t, count)
+}
+
+func redisTestPodField(t *testing.T, entry PodEntry) string {
+	t.Helper()
+	value, err := json.Marshal(entry)
+	require.NoError(t, err)
+	return string(value)
 }

--- a/tests/profiling/kv_cache_index/README.md
+++ b/tests/profiling/kv_cache_index/README.md
@@ -35,6 +35,44 @@ use the -bench option to filter
 go test -bench=Redis -benchmem
 ```
 
+### Redis Clear benchmarks
+
+The Redis Clear benchmark has two modes:
+
+* Default mode uses `miniredis`, so it needs no external Redis server and is suitable for quick local checks.
+* Real Redis mode is guarded by the `redis_real_bench` build tag and requires `KV_CACHE_BENCH_REDIS_ADDR`.
+
+Run the default `miniredis` benchmark:
+
+```bash
+go test ./tests/profiling/kv_cache_index \
+  -run '^$' \
+  -bench 'BenchmarkRedisClear(SharedKeyspace|PodFanout|Scale)' \
+  -benchmem \
+  -benchtime=3x \
+  -count=1
+```
+
+Run the same Clear scenarios against a real Redis server:
+
+```bash
+docker run --rm --name llmd-redis-bench \
+  -p 127.0.0.1:6380:6379 \
+  redis:7.4.1 redis-server --save '' --appendonly no
+```
+
+In another shell:
+
+```bash
+KV_CACHE_BENCH_REDIS_ADDR='redis://127.0.0.1:6380' \
+go test -tags redis_real_bench ./tests/profiling/kv_cache_index \
+  -run '^$' \
+  -bench 'BenchmarkRedisClearReal(Scale|SharedKeyspace|PodFanout)' \
+  -benchmem \
+  -benchtime=3x \
+  -count=1
+```
+
 ### Understanding the Output
 
 `BenchmarkInMemory_Add-12      192   6086106 ns/op    500 B/op      5 allocs/op`

--- a/tests/profiling/kv_cache_index/redis_clear_benchmark_test.go
+++ b/tests/profiling/kv_cache_index/redis_clear_benchmark_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/redis/go-redis/v9"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	redisClearTargetPod     = "pod-0"
+	redisClearSeedBatchSize = 1024
+)
+
+type redisClearBenchmarkCase struct {
+	name          string
+	requestKeys   int
+	podCount      int
+	unrelatedKeys int
+}
+
+var (
+	redisClearScaleCases = []redisClearBenchmarkCase{
+		{name: "targetKeys=512/unrelatedKeys=512/pods=8", requestKeys: 512, podCount: 8, unrelatedKeys: 512},
+		{name: "targetKeys=2048/unrelatedKeys=2048/pods=8", requestKeys: 2048, podCount: 8, unrelatedKeys: 2048},
+		{name: "targetKeys=8192/unrelatedKeys=8192/pods=8", requestKeys: 8192, podCount: 8, unrelatedKeys: 8192},
+		{name: "targetKeys=32768/unrelatedKeys=32768/pods=8", requestKeys: 32768, podCount: 8, unrelatedKeys: 32768},
+	}
+	redisClearSharedKeyspaceCases = []redisClearBenchmarkCase{
+		{name: "targetKeys=2048/unrelatedKeys=0/pods=8", requestKeys: 2048, podCount: 8},
+		{name: "targetKeys=2048/unrelatedKeys=8192/pods=8", requestKeys: 2048, podCount: 8, unrelatedKeys: 8192},
+		{name: "targetKeys=2048/unrelatedKeys=32768/pods=8", requestKeys: 2048, podCount: 8, unrelatedKeys: 32768},
+	}
+	redisClearPodFanoutCases = []redisClearBenchmarkCase{
+		{name: "targetKeys=2048/unrelatedKeys=8192/pods=1", requestKeys: 2048, podCount: 1, unrelatedKeys: 8192},
+		{name: "targetKeys=2048/unrelatedKeys=8192/pods=8", requestKeys: 2048, podCount: 8, unrelatedKeys: 8192},
+		{name: "targetKeys=2048/unrelatedKeys=8192/pods=32", requestKeys: 2048, podCount: 32, unrelatedKeys: 8192},
+	}
+)
+
+func BenchmarkRedisClearScaleLegacyFullScan(b *testing.B) {
+	benchmarkRedisClearCases(b, false, redisClearScaleCases)
+}
+
+func BenchmarkRedisClearScaleReverseIndex(b *testing.B) {
+	benchmarkRedisClearCases(b, true, redisClearScaleCases)
+}
+
+func BenchmarkRedisClearSharedKeyspaceLegacyFullScan(b *testing.B) {
+	benchmarkRedisClearCases(b, false, redisClearSharedKeyspaceCases)
+}
+
+func BenchmarkRedisClearSharedKeyspaceReverseIndex(b *testing.B) {
+	benchmarkRedisClearCases(b, true, redisClearSharedKeyspaceCases)
+}
+
+func BenchmarkRedisClearPodFanoutLegacyFullScan(b *testing.B) {
+	benchmarkRedisClearCases(b, false, redisClearPodFanoutCases)
+}
+
+func BenchmarkRedisClearPodFanoutReverseIndex(b *testing.B) {
+	benchmarkRedisClearCases(b, true, redisClearPodFanoutCases)
+}
+
+func benchmarkRedisClearCases(b *testing.B, reverseIndex bool, cases []redisClearBenchmarkCase) {
+	b.Helper()
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			benchmarkRedisClear(b, tc, reverseIndex)
+		})
+	}
+}
+
+func benchmarkRedisClear(b *testing.B, tc redisClearBenchmarkCase, reverseIndex bool) {
+	b.Helper()
+	server, cleanup := setupMiniredis(b)
+	b.Cleanup(cleanup)
+	benchmarkRedisClearWithAddress(b, server.Addr(), tc, reverseIndex)
+}
+
+func benchmarkRedisClearWithAddress(b *testing.B, address string, tc redisClearBenchmarkCase, reverseIndex bool) {
+	b.Helper()
+	index, err := kvblock.NewRedisIndex(&kvblock.RedisIndexConfig{Address: address})
+	if err != nil {
+		b.Fatalf("failed to create redis index: %v", err)
+	}
+	redisIndex, ok := index.(*kvblock.RedisIndex)
+	if !ok {
+		b.Fatalf("unexpected index type %T", index)
+	}
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+	b.Cleanup(func() {
+		if err := redisIndex.RedisClient.FlushDB(ctx).Err(); err != nil {
+			b.Fatalf("failed to flush redis during cleanup: %v", err)
+		}
+		if err := redisIndex.RedisClient.Close(); err != nil {
+			b.Fatalf("failed to close redis client: %v", err)
+		}
+	})
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		if err := redisIndex.RedisClient.FlushDB(ctx).Err(); err != nil {
+			b.Fatalf("failed to flush redis: %v", err)
+		}
+		seedRedisClearData(b, ctx, redisIndex, tc, reverseIndex)
+		b.StartTimer()
+
+		if reverseIndex {
+			err = redisIndex.Clear(ctx, redisClearTargetPod)
+		} else {
+			err = legacyRedisClear(ctx, redisIndex.RedisClient, redisClearTargetPod)
+		}
+		if err != nil {
+			b.Fatalf("failed to clear redis data: %v", err)
+		}
+	}
+}
+
+func seedRedisClearData(
+	b *testing.B,
+	ctx context.Context,
+	index *kvblock.RedisIndex,
+	tc redisClearBenchmarkCase,
+	reverseIndex bool,
+) {
+	b.Helper()
+	if reverseIndex {
+		seedRedisClearReverseIndexData(b, ctx, index, tc)
+	} else {
+		seedRedisClearLegacyData(b, ctx, index, tc)
+	}
+	seedUnrelatedRedisData(b, ctx, index, tc.unrelatedKeys)
+}
+
+func seedRedisClearReverseIndexData(
+	b *testing.B,
+	ctx context.Context,
+	index *kvblock.RedisIndex,
+	tc redisClearBenchmarkCase,
+) {
+	b.Helper()
+	requestKeys := make([]kvblock.BlockHash, tc.requestKeys)
+	for key := range requestKeys {
+		requestKeys[key] = redisClearBlockHash(b, key+1)
+	}
+	for pod := 0; pod < tc.podCount; pod++ {
+		entry := kvblock.PodEntry{PodIdentifier: fmt.Sprintf("pod-%d", pod), DeviceTier: "gpu"}
+		for start := 0; start < len(requestKeys); start += redisClearSeedBatchSize {
+			end := min(start+redisClearSeedBatchSize, len(requestKeys))
+			if err := index.Add(ctx, nil, requestKeys[start:end], []kvblock.PodEntry{entry}); err != nil {
+				b.Fatalf("failed to seed redis data through Add: %v", err)
+			}
+		}
+	}
+}
+
+func seedRedisClearLegacyData(
+	b *testing.B,
+	ctx context.Context,
+	index *kvblock.RedisIndex,
+	tc redisClearBenchmarkCase,
+) {
+	b.Helper()
+	pipe := index.RedisClient.Pipeline()
+	pending := 0
+	for key := 0; key < tc.requestKeys; key++ {
+		redisKey := redisClearBlockHash(b, key+1).String()
+		for pod := 0; pod < tc.podCount; pod++ {
+			entry := kvblock.PodEntry{PodIdentifier: fmt.Sprintf("pod-%d", pod), DeviceTier: "gpu"}
+			field := redisClearPodField(b, entry)
+			pipe.HSet(ctx, redisKey, field, "")
+			pending++
+			if pending == redisClearSeedBatchSize {
+				execRedisClearSeedPipeline(b, ctx, pipe)
+				pipe = index.RedisClient.Pipeline()
+				pending = 0
+			}
+		}
+	}
+	if pending > 0 {
+		execRedisClearSeedPipeline(b, ctx, pipe)
+	}
+}
+
+func seedUnrelatedRedisData(b *testing.B, ctx context.Context, index *kvblock.RedisIndex, count int) {
+	b.Helper()
+	if count == 0 {
+		return
+	}
+	pipe := index.RedisClient.Pipeline()
+	pending := 0
+	for key := 0; key < count; key++ {
+		field := redisClearPodField(b, kvblock.PodEntry{PodIdentifier: "other", DeviceTier: "gpu"})
+		pipe.HSet(ctx, fmt.Sprintf("unrelated:%d", key), field, "")
+		pending++
+		if pending == redisClearSeedBatchSize {
+			execRedisClearSeedPipeline(b, ctx, pipe)
+			pipe = index.RedisClient.Pipeline()
+			pending = 0
+		}
+	}
+	if pending > 0 {
+		execRedisClearSeedPipeline(b, ctx, pipe)
+	}
+}
+
+func execRedisClearSeedPipeline(b *testing.B, ctx context.Context, pipe redis.Pipeliner) {
+	b.Helper()
+	if _, err := pipe.Exec(ctx); err != nil {
+		b.Fatalf("failed to seed redis data: %v", err)
+	}
+}
+
+func legacyRedisClear(ctx context.Context, client *redis.Client, podIdentifier string) error {
+	const scanBatch int64 = 1024
+	var cursor uint64
+	for {
+		keys, next, err := client.Scan(ctx, cursor, "*", scanBatch).Result()
+		if err != nil {
+			return err
+		}
+		for _, key := range keys {
+			if strings.HasPrefix(key, "engine:") {
+				continue
+			}
+			fields, err := client.HKeys(ctx, key).Result()
+			if err != nil {
+				return err
+			}
+			var stale []string
+			for _, field := range fields {
+				var entry kvblock.PodEntry
+				if json.Unmarshal([]byte(field), &entry) == nil && entry.PodIdentifier == podIdentifier {
+					stale = append(stale, field)
+				}
+			}
+			if len(stale) > 0 {
+				if err := client.HDel(ctx, key, stale...).Err(); err != nil {
+					return err
+				}
+			}
+		}
+		if cursor = next; cursor == 0 {
+			return nil
+		}
+	}
+}
+
+func redisClearBlockHash(b *testing.B, key int) kvblock.BlockHash {
+	b.Helper()
+	value, err := strconv.ParseUint(strconv.FormatInt(int64(key), 10), 10, 64)
+	if err != nil {
+		b.Fatalf("failed to convert benchmark key: %v", err)
+	}
+	return kvblock.BlockHash(value)
+}
+
+func redisClearPodField(b *testing.B, entry kvblock.PodEntry) string {
+	b.Helper()
+	value, err := json.Marshal(entry)
+	if err != nil {
+		b.Fatalf("failed to encode pod entry: %v", err)
+	}
+	return string(value)
+}

--- a/tests/profiling/kv_cache_index/redis_clear_real_benchmark_test.go
+++ b/tests/profiling/kv_cache_index/redis_clear_real_benchmark_test.go
@@ -1,0 +1,63 @@
+//go:build redis_real_bench
+
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+const redisClearRealAddressEnv = "KV_CACHE_BENCH_REDIS_ADDR"
+
+func BenchmarkRedisClearRealScaleLegacyFullScan(b *testing.B) {
+	benchmarkRedisClearRealCases(b, false, redisClearScaleCases)
+}
+
+func BenchmarkRedisClearRealScaleReverseIndex(b *testing.B) {
+	benchmarkRedisClearRealCases(b, true, redisClearScaleCases)
+}
+
+func BenchmarkRedisClearRealSharedKeyspaceLegacyFullScan(b *testing.B) {
+	benchmarkRedisClearRealCases(b, false, redisClearSharedKeyspaceCases)
+}
+
+func BenchmarkRedisClearRealSharedKeyspaceReverseIndex(b *testing.B) {
+	benchmarkRedisClearRealCases(b, true, redisClearSharedKeyspaceCases)
+}
+
+func BenchmarkRedisClearRealPodFanoutLegacyFullScan(b *testing.B) {
+	benchmarkRedisClearRealCases(b, false, redisClearPodFanoutCases)
+}
+
+func BenchmarkRedisClearRealPodFanoutReverseIndex(b *testing.B) {
+	benchmarkRedisClearRealCases(b, true, redisClearPodFanoutCases)
+}
+
+func benchmarkRedisClearRealCases(b *testing.B, reverseIndex bool, cases []redisClearBenchmarkCase) {
+	b.Helper()
+	address := os.Getenv(redisClearRealAddressEnv)
+	if address == "" {
+		b.Skipf("%s is required for real Redis benchmarks", redisClearRealAddressEnv)
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			benchmarkRedisClearWithAddress(b, address, tc, reverseIndex)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Optimize Redis/Valkey `Clear` by maintaining a per-pod reverse index.

`Clear(ctx, podIdentifier)` now scans `kvblock:pod:<podIdentifier>:entries` and removes entries with pipelined `HDEL` + `SREM`, instead of scanning the full Redis keyspace.

## Notes

- `Add` records reverse-index members.
- `Evict` removes reverse-index members.
- `Clear` drops malformed reverse-index members and continues.
- Existing Redis data written before this change does not have reverse-index members. Existing deployments should flush the dedicated Redis/Valkey index DB during upgrade, or run a one-time full-scan migration, before relying on `Clear` for pre-upgrade entries.
- Trade-off: `Add` now writes both the request-key hash and the per-pod reverse-index set, and the set member stores `<requestKey>\0<encodedPodField>`. This adds write and memory overhead in exchange for avoiding full keyspace scans during `Clear`.

## Benchmark

Real Redis `redis:7.4.1`, persistence disabled:

| scenario | legacy full scan | reverse index | speedup |
| --- | ---: | ---: | ---: |
| 512 target / 512 unrelated / 8 pods | 42.70 ms/op | 1.56 ms/op | 27.41x |
| 2,048 target / 2,048 unrelated / 8 pods | 167.45 ms/op | 3.20 ms/op | 52.28x |
| 32,768 target / 32,768 unrelated / 8 pods | 2,789.52 ms/op | 66.07 ms/op | 42.22x |
| 2,048 target / 32,768 unrelated / 8 pods | 907.41 ms/op | 4.14 ms/op | 219.18x |

## Testing

- `make lint`
- `go test ./pkg/kvcache/kvblock`
- `go test ./pkg/kvevents`
- `go test ./tests/profiling/kv_cache_index -run '^$'`
- `go test -tags redis_real_bench ./tests/profiling/kv_cache_index -run '^$'`
- `go test -race ./pkg/kvcache/kvblock -run 'TestRedis|TestValkeyIndexBehavior/(ClearBasic|ClearIsolatesOtherPods|ClearAllTiers|ClearThenReAdd|StressHighCardinality)' -count=1`

Fixes https://github.com/llm-d/llm-d-kv-cache/issues/672
