### PR TITLE
fix(kvcache): normalize storage tier scoring weights

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,7 +196,7 @@ Pod C:        no    -     -     -     -     → score = 0 blocks (no prefix)
 
 Even if Pod C happened to hold `B3` and `B4`, those entries are unusable without the preceding chain, and the score is zero.
 
-When blocks are stored across memory tiers, each matching block's contribution is weighted by tier. For a block cached on multiple tiers at once, the scorer takes the maximum weight. Defaults are `gpu = 1.0`, `cpu = 0.8`.
+When blocks are stored across memory tiers, each matching block's contribution is weighted by tier. For a block cached on multiple tiers at once, the scorer takes the maximum weight. Defaults are `gpu = 1.0`, `cpu = 0.8`, `shared_storage = 0.4`, and `object_store = 0.2`. Unknown tiers do not contribute to the score unless configured.
 
 -----
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,14 @@ Here's a complete configuration example with all options:
     {
       "name": "cpu",
       "weight": 0.8
+    },
+    {
+      "name": "shared_storage",
+      "weight": 0.4
+    },
+    {
+      "name": "object_store",
+      "weight": 0.2
     }
   ]
 }

--- a/pkg/kvcache/backend.go
+++ b/pkg/kvcache/backend.go
@@ -27,5 +27,7 @@ func DefaultKVCacheBackendConfig() []*KVCacheBackendConfig {
 	return []*KVCacheBackendConfig{
 		{Name: "gpu", Weight: 1.0},
 		{Name: "cpu", Weight: 0.8},
+		{Name: "shared_storage", Weight: 0.4},
+		{Name: "object_store", Weight: 0.2},
 	}
 }

--- a/pkg/kvcache/kvblock_scorer.go
+++ b/pkg/kvcache/kvblock_scorer.go
@@ -19,6 +19,7 @@ package kvcache
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
 )
@@ -28,7 +29,8 @@ type KVScoringStrategy string
 
 const (
 	// LongestPrefixMatch Score by longest consecutive match from start.
-	LongestPrefixMatch KVScoringStrategy = "LongestPrefix"
+	LongestPrefixMatch      KVScoringStrategy = "LongestPrefix"
+	unknownDeviceTierWeight                   = 0.0
 )
 
 // KVBlockScorerConfig holds the configuration for the KVBlockScorer.
@@ -63,7 +65,7 @@ func NewKVBlockScorer(config *KVBlockScorerConfig) (KVBlockScorer, error) {
 		// Build weight map from list of BackendConfigs for efficient lookup
 		weightMap := make(map[string]float64)
 		for _, medium := range config.BackendConfigs {
-			weightMap[medium.Name] = medium.Weight
+			weightMap[strings.ToLower(medium.Name)] = medium.Weight
 		}
 
 		return &LongestPrefixScorer{
@@ -90,9 +92,9 @@ func (s *LongestPrefixScorer) Strategy() KVScoringStrategy {
 // device tiers for the given entries. The caller must clear dst before calling.
 func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWeights map[string]float64) {
 	for _, entry := range entries {
-		weight := 1.0
+		weight := unknownDeviceTierWeight
 		if mediumWeights != nil {
-			if w, exists := mediumWeights[entry.DeviceTier]; exists {
+			if w, exists := mediumWeights[strings.ToLower(entry.DeviceTier)]; exists {
 				weight = w
 			}
 		}

--- a/pkg/kvcache/kvblock_scorer_test.go
+++ b/pkg/kvcache/kvblock_scorer_test.go
@@ -99,6 +99,49 @@ func TestLongestPrefixScorerDifferentTiers(t *testing.T) {
 	}
 }
 
+func TestLongestPrefixScorerDefaultStorageTierWeights(t *testing.T) {
+	scorer, err := kvcache.NewKVBlockScorer(kvcache.DefaultKVBlockScorerConfig())
+	assert.NoError(t, err)
+
+	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002})
+	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {
+			{PodIdentifier: podA, DeviceTier: "gpu"},
+			{PodIdentifier: podB, DeviceTier: "shared_storage"},
+		},
+		1002: {
+			{PodIdentifier: podA, DeviceTier: "gpu"},
+			{PodIdentifier: podB, DeviceTier: "shared_storage"},
+		},
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.InDelta(t, 2.0, scored[podA], 0.0001)
+	assert.InDelta(t, 0.8, scored[podB], 0.0001)
+	assert.Less(t, scored[podB], scored[podA])
+}
+
+func TestLongestPrefixScorerUnknownTierDoesNotScoreAsGPU(t *testing.T) {
+	scorer := &kvcache.LongestPrefixScorer{
+		MediumWeights: map[string]float64{
+			"gpu": 1.0,
+		},
+	}
+	blockKeys := int64KeysToKVBlockKeys([]uint64{1001})
+	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {
+			{PodIdentifier: podA, DeviceTier: "unknown-tier"},
+			{PodIdentifier: podB, DeviceTier: "gpu"},
+		},
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.InDelta(t, 0.0, scored[podA], 0.0001)
+	assert.InDelta(t, 1.0, scored[podB], 0.0001)
+}
+
 func int64KeysToKVBlockKeys(keys []uint64) []kvblock.BlockHash {
 	kvKeys := make([]kvblock.BlockHash, len(keys))
 	for i, key := range keys {


### PR DESCRIPTION
## Summary

Fixes KV cache scoring for storage offloading tiers.

The FS backend publishes storage events with tiers such as `SHARED_STORAGE` and `OBJECT_STORE`, while the event pool stores device tiers in lowercase. This PR makes scorer backend weight lookup case-insensitive and adds default low weights for storage tiers:

- `shared_storage = 0.4`
- `object_store = 0.2`

Unknown tiers now contribute `0.0` instead of silently falling back to GPU-equivalent weight `1.0`.

## Changes

- Add default backend weights for `shared_storage` and `object_store`.
- Normalize backend config names and incoming device tiers to lowercase before scorer lookup.
- Prevent unknown tiers from scoring as GPU hits.
- Add regression coverage for storage tier scoring and unknown tier fallback.
- Update configuration and architecture docs with the new defaults.

https://github.com/llm-d/llm-d-kv-cache/blob/7bfda47558fe457e644c0dbc69b378321ba69ada/kv_connectors/llmd_fs_backend/llmd_fs_backend/event_publisher.py#L31-L36