### PR TITLE
Add Prometheus alerting rules for KV-cache metrics

### DIFF
--- a/kv_connectors/llmd_fs_backend/docs/deployment/monitoring/kvcache-alerts.rules.yml
+++ b/kv_connectors/llmd_fs_backend/docs/deployment/monitoring/kvcache-alerts.rules.yml
@@ -1,0 +1,130 @@
+# Default Prometheus alerting rules for llm-d-kv-cache metrics.
+#
+# This is the canonical, plain-format rules file. It is consumed two ways:
+#   1. Wired into the example prometheus.yml via `rule_files` (see prometheus.yaml).
+#   2. Mirrored into a PrometheusRule CRD for prometheus-operator setups
+#      (see prometheus-rules.yaml). Keep the two in sync.
+#
+# The kvcache_* series are exported by the kv-cache library (pkg/kvcache/metrics)
+# wherever it runs: embedded in the EPP (precise-prefix-cache-scorer with
+# enableMetrics: true) or as a standalone service. Make sure your Prometheus
+# scrapes that /metrics endpoint, not only vLLM.
+#
+# Thresholds below are conservative defaults. Tune `expr` thresholds and `for`
+# durations to your workload before relying on them for paging.
+groups:
+  - name: kvcache.index.rules
+    rules:
+      # Hit ratio collapses while the index is actually being queried. A low
+      # ratio under real traffic usually means a stale index or a broken
+      # KV-events stream feeding the index.
+      - alert: KVCacheLowIndexHitRatio
+        expr: |
+          (
+            sum(rate(kvcache_index_lookup_hits_total[5m]))
+            /
+            sum(rate(kvcache_index_lookup_requests_total[5m]))
+          ) < 0.3
+          and
+          sum(rate(kvcache_index_lookup_requests_total[5m])) > 0.1
+        for: 15m
+        labels:
+          severity: warning
+          component: kvcache-index
+        annotations:
+          summary: "KV-cache index hit ratio is low"
+          description: >-
+            KV-cache index hit ratio is {{ $value | humanizePercentage }} over the
+            last 5m (threshold 30%) while lookups are still happening. This often
+            indicates a stale index or a broken KV-events stream.
+
+      # P99 lookup latency is high. Lookup is on the request scheduling path, so
+      # sustained high latency directly adds to scheduling overhead.
+      - alert: KVCacheHighLookupLatency
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum by (le) (rate(kvcache_index_lookup_latency_seconds_bucket[5m]))
+          ) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          component: kvcache-index
+        annotations:
+          summary: "KV-cache index P99 lookup latency is high"
+          description: >-
+            P99 KV-cache index lookup latency is {{ $value | humanizeDuration }}
+            over the last 5m (threshold 500ms).
+
+      # Eviction rate spikes well above its own recent baseline. Relevant after
+      # eager index invalidation on AllBlocksCleared (#626): a flood of evictions
+      # can signal repeated cache resets or thrashing.
+      - alert: KVCacheAbnormalEvictionSpike
+        expr: |
+          rate(kvcache_index_evictions_total[5m])
+          > 5 * (rate(kvcache_index_evictions_total[1h]) + 0.001)
+          and
+          rate(kvcache_index_evictions_total[5m]) > 1
+        for: 10m
+        labels:
+          severity: warning
+          component: kvcache-index
+        annotations:
+          summary: "KV-cache index eviction rate spike"
+          description: >-
+            KV-cache index eviction rate is {{ $value | humanize }}/s over the
+            last 5m, more than 5x its 1h baseline. Possible cache thrashing or
+            repeated AllBlocksCleared resets.
+
+  - name: kvcache.tokenization.rules
+    rules:
+      # P99 tokenization latency is high. Tokenization sits in front of indexing;
+      # a slow tokenizer pool starves the index and adds request latency.
+      - alert: KVCacheHighTokenizationLatency
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum by (le, tokenizer) (rate(kvcache_tokenization_tokenization_latency_seconds_bucket[5m]))
+          ) > 1
+        for: 10m
+        labels:
+          severity: warning
+          component: kvcache-tokenization
+        annotations:
+          summary: "KV-cache tokenization P99 latency is high"
+          description: >-
+            P99 tokenization latency for tokenizer "{{ $labels.tokenizer }}" is
+            {{ $value | humanizeDuration }} over the last 5m (threshold 1s).
+
+  # Optional vLLM-side alerts for the example deployment. These rely on vLLM's
+  # own metrics (vllm:*) being scraped; remove this group if you only scrape the
+  # kv-cache library.
+  - name: kvcache.vllm.rules
+    rules:
+      - alert: VLLMHighRequestBacklog
+        expr: sum(vllm:num_requests_waiting) > 50
+        for: 10m
+        labels:
+          severity: warning
+          component: vllm
+        annotations:
+          summary: "vLLM request backlog is high"
+          description: >-
+            {{ $value | humanize }} requests are waiting in the vLLM queue over
+            the last 10m (threshold 50). The serving tier may be saturated.
+
+      - alert: VLLMHighTTFT
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum by (le) (rate(vllm:time_to_first_token_seconds_bucket[5m]))
+          ) > 5
+        for: 10m
+        labels:
+          severity: warning
+          component: vllm
+        annotations:
+          summary: "vLLM P99 time-to-first-token is high"
+          description: >-
+            P99 time-to-first-token is {{ $value | humanizeDuration }} over the
+            last 5m (threshold 5s).

--- a/kv_connectors/llmd_fs_backend/docs/deployment/monitoring/kvcache-alerts.test.yaml
+++ b/kv_connectors/llmd_fs_backend/docs/deployment/monitoring/kvcache-alerts.test.yaml
@@ -1,0 +1,201 @@
+# promtool unit tests for kvcache-alerts.rules.yml.
+#
+# Run from this directory:
+#   promtool test rules kvcache-alerts.test.yaml
+# or without a local promtool install:
+#   docker run --rm --entrypoint=/bin/promtool -v "$PWD":/work -w /work \
+#     prom/prometheus:v2.53.0 test rules kvcache-alerts.test.yaml
+rule_files:
+  - kvcache-alerts.rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  # Low hit ratio under real traffic -> KVCacheLowIndexHitRatio fires.
+  - interval: 1m
+    input_series:
+      # 10 requests/min, 1 hit/min => 10% hit ratio, well under 30%.
+      - series: 'kvcache_index_lookup_requests_total'
+        values: '0+10x30'
+      - series: 'kvcache_index_lookup_hits_total'
+        values: '0+1x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KVCacheLowIndexHitRatio
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kvcache-index
+            exp_annotations:
+              summary: "KV-cache index hit ratio is low"
+              description: >-
+                KV-cache index hit ratio is 10% over the last 5m (threshold 30%)
+                while lookups are still happening. This often indicates a stale
+                index or a broken KV-events stream.
+
+  # Healthy hit ratio -> no alert. Also guards the low-traffic suppression path.
+  - interval: 1m
+    input_series:
+      - series: 'kvcache_index_lookup_requests_total'
+        values: '0+10x30'
+      - series: 'kvcache_index_lookup_hits_total'
+        values: '0+9x30'   # 90% hit ratio
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KVCacheLowIndexHitRatio
+        exp_alerts: []
+
+  # No traffic: requests rate below the floor -> must not fire (no paging on an
+  # idle index).
+  - interval: 1m
+    input_series:
+      - series: 'kvcache_index_lookup_requests_total'
+        values: '0+0x30'
+      - series: 'kvcache_index_lookup_hits_total'
+        values: '0+0x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: KVCacheLowIndexHitRatio
+        exp_alerts: []
+
+  # High P99 lookup latency -> KVCacheHighLookupLatency fires.
+  # All observations land above 1s (> 0.5s threshold).
+  - interval: 1m
+    input_series:
+      - series: 'kvcache_index_lookup_latency_seconds_bucket{le="0.5"}'
+        values: '0+0x30'
+      - series: 'kvcache_index_lookup_latency_seconds_bucket{le="1"}'
+        values: '0+0x30'
+      - series: 'kvcache_index_lookup_latency_seconds_bucket{le="+Inf"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KVCacheHighLookupLatency
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kvcache-index
+            exp_annotations:
+              summary: "KV-cache index P99 lookup latency is high"
+              description: >-
+                P99 KV-cache index lookup latency is 1s over the last 5m
+                (threshold 500ms).
+
+  # Low lookup latency -> no alert. Everything within the 0.1s bucket.
+  - interval: 1m
+    input_series:
+      - series: 'kvcache_index_lookup_latency_seconds_bucket{le="0.1"}'
+        values: '0+10x30'
+      - series: 'kvcache_index_lookup_latency_seconds_bucket{le="0.5"}'
+        values: '0+10x30'
+      - series: 'kvcache_index_lookup_latency_seconds_bucket{le="+Inf"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KVCacheHighLookupLatency
+        exp_alerts: []
+
+  # Eviction spike: long flat baseline (1/min) then a sharp jump to 600/min.
+  # The [5m] vs [1h] comparison fires while the spike is fresh (the 1h baseline
+  # catches up afterwards, which intentionally clears the alert). Evaluate ~11m
+  # into the spike, after the 10m "for" has elapsed.
+  - interval: 1m
+    input_series:
+      - series: 'kvcache_index_evictions_total'
+        values: '0+1x120 120+600x20'
+    alert_rule_test:
+      - eval_time: 132m
+        alertname: KVCacheAbnormalEvictionSpike
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kvcache-index
+            exp_annotations:
+              summary: "KV-cache index eviction rate spike"
+              description: >-
+                KV-cache index eviction rate is 10/s over the last 5m, more than
+                5x its 1h baseline. Possible cache thrashing or repeated
+                AllBlocksCleared resets.
+
+  # Steady eviction rate -> no spike alert even though evictions are nonzero.
+  - interval: 1m
+    input_series:
+      - series: 'kvcache_index_evictions_total'
+        values: '0+120x100'   # constant 2/s
+    alert_rule_test:
+      - eval_time: 95m
+        alertname: KVCacheAbnormalEvictionSpike
+        exp_alerts: []
+
+  # High tokenization P99 latency -> KVCacheHighTokenizationLatency fires,
+  # carrying the tokenizer label through.
+  - interval: 1m
+    input_series:
+      - series: 'kvcache_tokenization_tokenization_latency_seconds_bucket{le="1",tokenizer="Qwen/Qwen3-32B"}'
+        values: '0+0x30'
+      - series: 'kvcache_tokenization_tokenization_latency_seconds_bucket{le="2.5",tokenizer="Qwen/Qwen3-32B"}'
+        values: '0+10x30'
+      - series: 'kvcache_tokenization_tokenization_latency_seconds_bucket{le="+Inf",tokenizer="Qwen/Qwen3-32B"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KVCacheHighTokenizationLatency
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: kvcache-tokenization
+              tokenizer: "Qwen/Qwen3-32B"
+            exp_annotations:
+              summary: "KV-cache tokenization P99 latency is high"
+              description: >-
+                P99 tokenization latency for tokenizer "Qwen/Qwen3-32B" is 2.485s
+                over the last 5m (threshold 1s).
+
+  # vLLM request backlog over threshold -> VLLMHighRequestBacklog fires.
+  - interval: 1m
+    input_series:
+      - series: 'vllm:num_requests_waiting{model_name="Qwen/Qwen3-32B"}'
+        values: '100x30'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VLLMHighRequestBacklog
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: vllm
+            exp_annotations:
+              summary: "vLLM request backlog is high"
+              description: >-
+                100 requests are waiting in the vLLM queue over the last 10m
+                (threshold 50). The serving tier may be saturated.
+
+  # vLLM backlog within bounds -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'vllm:num_requests_waiting{model_name="Qwen/Qwen3-32B"}'
+        values: '5x30'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: VLLMHighRequestBacklog
+        exp_alerts: []
+
+  # High vLLM TTFT P99 -> VLLMHighTTFT fires (all samples above 5s threshold).
+  - interval: 1m
+    input_series:
+      - series: 'vllm:time_to_first_token_seconds_bucket{le="5"}'
+        values: '0+0x30'
+      - series: 'vllm:time_to_first_token_seconds_bucket{le="10"}'
+        values: '0+10x30'
+      - series: 'vllm:time_to_first_token_seconds_bucket{le="+Inf"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: VLLMHighTTFT
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: vllm
+            exp_annotations:
+              summary: "vLLM P99 time-to-first-token is high"
+              description: >-
+                P99 time-to-first-token is 9.95s over the last 5m (threshold 5s).

--- a/kv_connectors/llmd_fs_backend/docs/deployment/monitoring/prometheus-rules.yaml
+++ b/kv_connectors/llmd_fs_backend/docs/deployment/monitoring/prometheus-rules.yaml
@@ -1,0 +1,119 @@
+# PrometheusRule for prometheus-operator setups. Companion to
+# prometheus-servicemonitor.yaml. The `release` label selects which Prometheus
+# instance picks the rules up; adjust it to match your operator's ruleSelector
+# (e.g. the kube-prometheus-stack release name).
+#
+# Rule content is kept identical to kvcache-alerts.rules.yml — update both
+# together. If not using the operator, wire kvcache-alerts.rules.yml into your
+# prometheus.yml via `rule_files` instead (see prometheus.yaml).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kvcache-alerts
+  labels:
+    app: vllm-storage
+    release: prometheus
+spec:
+  groups:
+    - name: kvcache.index.rules
+      rules:
+        - alert: KVCacheLowIndexHitRatio
+          expr: |
+            (
+              sum(rate(kvcache_index_lookup_hits_total[5m]))
+              /
+              sum(rate(kvcache_index_lookup_requests_total[5m]))
+            ) < 0.3
+            and
+            sum(rate(kvcache_index_lookup_requests_total[5m])) > 0.1
+          for: 15m
+          labels:
+            severity: warning
+            component: kvcache-index
+          annotations:
+            summary: "KV-cache index hit ratio is low"
+            description: >-
+              KV-cache index hit ratio is {{ $value | humanizePercentage }} over the
+              last 5m (threshold 30%) while lookups are still happening. This often
+              indicates a stale index or a broken KV-events stream.
+
+        - alert: KVCacheHighLookupLatency
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le) (rate(kvcache_index_lookup_latency_seconds_bucket[5m]))
+            ) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+            component: kvcache-index
+          annotations:
+            summary: "KV-cache index P99 lookup latency is high"
+            description: >-
+              P99 KV-cache index lookup latency is {{ $value | humanizeDuration }}
+              over the last 5m (threshold 500ms).
+
+        - alert: KVCacheAbnormalEvictionSpike
+          expr: |
+            rate(kvcache_index_evictions_total[5m])
+            > 5 * (rate(kvcache_index_evictions_total[1h]) + 0.001)
+            and
+            rate(kvcache_index_evictions_total[5m]) > 1
+          for: 10m
+          labels:
+            severity: warning
+            component: kvcache-index
+          annotations:
+            summary: "KV-cache index eviction rate spike"
+            description: >-
+              KV-cache index eviction rate is {{ $value | humanize }}/s over the
+              last 5m, more than 5x its 1h baseline. Possible cache thrashing or
+              repeated AllBlocksCleared resets.
+
+    - name: kvcache.tokenization.rules
+      rules:
+        - alert: KVCacheHighTokenizationLatency
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le, tokenizer) (rate(kvcache_tokenization_tokenization_latency_seconds_bucket[5m]))
+            ) > 1
+          for: 10m
+          labels:
+            severity: warning
+            component: kvcache-tokenization
+          annotations:
+            summary: "KV-cache tokenization P99 latency is high"
+            description: >-
+              P99 tokenization latency for tokenizer "{{ $labels.tokenizer }}" is
+              {{ $value | humanizeDuration }} over the last 5m (threshold 1s).
+
+    - name: kvcache.vllm.rules
+      rules:
+        - alert: VLLMHighRequestBacklog
+          expr: sum(vllm:num_requests_waiting) > 50
+          for: 10m
+          labels:
+            severity: warning
+            component: vllm
+          annotations:
+            summary: "vLLM request backlog is high"
+            description: >-
+              {{ $value | humanize }} requests are waiting in the vLLM queue over
+              the last 10m (threshold 50). The serving tier may be saturated.
+
+        - alert: VLLMHighTTFT
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le) (rate(vllm:time_to_first_token_seconds_bucket[5m]))
+            ) > 5
+          for: 10m
+          labels:
+            severity: warning
+            component: vllm
+          annotations:
+            summary: "vLLM P99 time-to-first-token is high"
+            description: >-
+              P99 time-to-first-token is {{ $value | humanizeDuration }} over the
+              last 5m (threshold 5s).

--- a/kv_connectors/llmd_fs_backend/docs/deployment/monitoring/prometheus.yaml
+++ b/kv_connectors/llmd_fs_backend/docs/deployment/monitoring/prometheus.yaml
@@ -6,10 +6,121 @@ data:
   prometheus.yml: |
     global:
       scrape_interval: 15s
+    # Load the kv-cache alerting rules (mounted from this same ConfigMap).
+    rule_files:
+      - /etc/prometheus/kvcache-alerts.rules.yml
     scrape_configs:
       - job_name: vllm
         static_configs:
           - targets: ["vllm-storage-svc:8000"]
+      # kvcache_* metrics are exported by the kv-cache library (e.g. the EPP
+      # running the precise-prefix-cache-scorer). Point this at that /metrics
+      # endpoint so the kvcache.* alert rules have data to evaluate.
+      # - job_name: kvcache
+      #   static_configs:
+      #     - targets: ["rtr-epp:9090"]
+  # Alerting rules, kept identical to kvcache-alerts.rules.yml in this directory.
+  # Mounted at /etc/prometheus/kvcache-alerts.rules.yml and referenced by
+  # rule_files above.
+  kvcache-alerts.rules.yml: |
+    groups:
+      - name: kvcache.index.rules
+        rules:
+          - alert: KVCacheLowIndexHitRatio
+            expr: |
+              (
+                sum(rate(kvcache_index_lookup_hits_total[5m]))
+                /
+                sum(rate(kvcache_index_lookup_requests_total[5m]))
+              ) < 0.3
+              and
+              sum(rate(kvcache_index_lookup_requests_total[5m])) > 0.1
+            for: 15m
+            labels:
+              severity: warning
+              component: kvcache-index
+            annotations:
+              summary: "KV-cache index hit ratio is low"
+              description: >-
+                KV-cache index hit ratio is {{ $value | humanizePercentage }} over the
+                last 5m (threshold 30%) while lookups are still happening. This often
+                indicates a stale index or a broken KV-events stream.
+          - alert: KVCacheHighLookupLatency
+            expr: |
+              histogram_quantile(
+                0.99,
+                sum by (le) (rate(kvcache_index_lookup_latency_seconds_bucket[5m]))
+              ) > 0.5
+            for: 10m
+            labels:
+              severity: warning
+              component: kvcache-index
+            annotations:
+              summary: "KV-cache index P99 lookup latency is high"
+              description: >-
+                P99 KV-cache index lookup latency is {{ $value | humanizeDuration }}
+                over the last 5m (threshold 500ms).
+          - alert: KVCacheAbnormalEvictionSpike
+            expr: |
+              rate(kvcache_index_evictions_total[5m])
+              > 5 * (rate(kvcache_index_evictions_total[1h]) + 0.001)
+              and
+              rate(kvcache_index_evictions_total[5m]) > 1
+            for: 10m
+            labels:
+              severity: warning
+              component: kvcache-index
+            annotations:
+              summary: "KV-cache index eviction rate spike"
+              description: >-
+                KV-cache index eviction rate is {{ $value | humanize }}/s over the
+                last 5m, more than 5x its 1h baseline. Possible cache thrashing or
+                repeated AllBlocksCleared resets.
+      - name: kvcache.tokenization.rules
+        rules:
+          - alert: KVCacheHighTokenizationLatency
+            expr: |
+              histogram_quantile(
+                0.99,
+                sum by (le, tokenizer) (rate(kvcache_tokenization_tokenization_latency_seconds_bucket[5m]))
+              ) > 1
+            for: 10m
+            labels:
+              severity: warning
+              component: kvcache-tokenization
+            annotations:
+              summary: "KV-cache tokenization P99 latency is high"
+              description: >-
+                P99 tokenization latency for tokenizer "{{ $labels.tokenizer }}" is
+                {{ $value | humanizeDuration }} over the last 5m (threshold 1s).
+      - name: kvcache.vllm.rules
+        rules:
+          - alert: VLLMHighRequestBacklog
+            expr: sum(vllm:num_requests_waiting) > 50
+            for: 10m
+            labels:
+              severity: warning
+              component: vllm
+            annotations:
+              summary: "vLLM request backlog is high"
+              description: >-
+                {{ $value | humanize }} requests are waiting in the vLLM queue over
+                the last 10m (threshold 50). The serving tier may be saturated.
+          - alert: VLLMHighTTFT
+            expr: |
+              histogram_quantile(
+                0.99,
+                sum by (le) (rate(vllm:time_to_first_token_seconds_bucket[5m]))
+              ) > 5
+            for: 10m
+            labels:
+              severity: warning
+              component: vllm
+            annotations:
+              summary: "vLLM P99 time-to-first-token is high"
+              description: >-
+                P99 time-to-first-token is {{ $value | humanizeDuration }} over the
+                last 5m (threshold 5s).
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kv_connectors/llmd_fs_backend/docs/monitoring.md
+++ b/kv_connectors/llmd_fs_backend/docs/monitoring.md
@@ -112,7 +112,67 @@ Watch the Grafana dashboard — you should see KV offload metrics (throughput, t
 curl -s http://localhost:8000/metrics | grep kv_offload
 ```
 
-## 6. Cleanup
+## 6. Alerting Rules
+
+Default Prometheus alerting rules for the KV-cache metrics live alongside the
+monitoring manifests:
+
+| File | Use |
+|------|-----|
+| `monitoring/kvcache-alerts.rules.yml` | Canonical plain rules file (source of truth). |
+| `monitoring/prometheus-rules.yaml` | `PrometheusRule` CRD for prometheus-operator setups. |
+| `monitoring/kvcache-alerts.test.yaml` | `promtool` unit tests for the rules. |
+
+The bundled `monitoring/prometheus.yaml` already wires the rules in via
+`rule_files`, so applying it (step 2) loads the alerts automatically. Confirm
+they loaded:
+
+```bash
+# Prometheus UI -> Status -> Rules, or:
+curl -s http://localhost:9090/api/v1/rules | grep -o '"name":"[A-Za-z]*"'
+```
+
+The alerts cover:
+
+- **KVCacheLowIndexHitRatio** — index hit ratio below 30% while lookups are
+  happening (stale index / broken KV-events stream).
+- **KVCacheHighLookupLatency** — P99 `kvcache_index_lookup_latency_seconds`
+  above 500ms.
+- **KVCacheAbnormalEvictionSpike** — eviction rate jumps >5x its 1h baseline
+  (cache thrashing or repeated `AllBlocksCleared` resets).
+- **KVCacheHighTokenizationLatency** — P99 tokenization latency above 1s.
+- **VLLMHighRequestBacklog** / **VLLMHighTTFT** — optional vLLM-side saturation
+  alerts.
+
+> The `kvcache_*` series are exported by the kv-cache library — embedded in the
+> EPP (precise-prefix-cache-scorer with `enableMetrics: true`) or as a
+> standalone service — **not** by vLLM. Make sure Prometheus scrapes that
+> `/metrics` endpoint. A commented-out `kvcache` scrape job is included in
+> `prometheus.yaml` as a starting point. Thresholds are conservative defaults;
+> tune them to your workload before paging on them.
+
+### Using the Prometheus Operator instead
+
+If you run the prometheus-operator (e.g. kube-prometheus-stack), skip the
+`rule_files` wiring and apply the CRD instead. Adjust the `release` label in
+`prometheus-rules.yaml` to match your operator's `ruleSelector`:
+
+```bash
+kubectl apply -f docs/deployment/monitoring/prometheus-rules.yaml
+```
+
+### Validating the rules
+
+```bash
+cd docs/deployment/monitoring
+# Syntax check + unit tests (uses the promtool from the prometheus image):
+docker run --rm --entrypoint=/bin/promtool -v "$PWD":/work -w /work \
+  prom/prometheus:v2.53.0 check rules kvcache-alerts.rules.yml
+docker run --rm --entrypoint=/bin/promtool -v "$PWD":/work -w /work \
+  prom/prometheus:v2.53.0 test rules kvcache-alerts.test.yaml
+```
+
+## 7. Cleanup
 
 Remove all monitoring and vLLM resources:
 


### PR DESCRIPTION
## Summary
Adds default Prometheus alerting rules for the KV-cache metrics,
so operators get sensible alerts out of the box instead of writing their own.

Rules (under `kv_connectors/llmd_fs_backend/docs/deployment/monitoring/`):
- **KVCacheLowIndexHitRatio** — hit ratio < 30% while lookups are happening
- **KVCacheHighLookupLatency** — P99 `kvcache_index_lookup_latency_seconds` > 500ms
- **KVCacheAbnormalEvictionSpike** — eviction rate > 5× its 1h baseline
- **KVCacheHighTokenizationLatency** — P99 tokenization latency > 1s
- **VLLMHighRequestBacklog** / **VLLMHighTTFT** — optional vLLM-side alerts

## Deliverables
- `kvcache-alerts.rules.yml` — canonical plain rules file
- `prometheus-rules.yaml` — `PrometheusRule` CRD for prometheus-operator setups
- `prometheus.yaml` — rules wired into the example config via `rule_files`
- `kvcache-alerts.test.yaml` — promtool unit tests
- `monitoring.md` — new "Alerting" section

Fixes: https://github.com/llm-d/llm-d-kv-cache/issues/664

