### PR TITLE
feat(telemetry): correlate kv-cache logs with traces via span context

### DIFF
--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -248,6 +248,9 @@ func (k *Indexer) ScoreTokens(
 	)
 	defer span.End()
 
+	// Enrich the context logger with trace_id/span_id so the log lines below
+	// (block keys, pod scores) can be correlated with this span's trace.
+	ctx = telemetry.LoggerWithSpanContext(ctx, span)
 	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvcache.ScoreTokens")
 
 	blockKeys, err := k.tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, tokens, modelName, extraFeatures)

--- a/pkg/kvcache/kvblock/traced_index.go
+++ b/pkg/kvcache/kvblock/traced_index.go
@@ -41,6 +41,7 @@ func (t *tracedIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHa
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
+	ctx = telemetry.LoggerWithSpanContext(ctx, span)
 
 	span.SetAttributes(
 		attribute.Int("llm_d.kv_cache.index.add.engine_key_count", len(engineKeys)),
@@ -64,6 +65,7 @@ func (t *tracedIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType,
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
+	ctx = telemetry.LoggerWithSpanContext(ctx, span)
 
 	span.SetAttributes(
 		attribute.String("llm_d.kv_cache.index.evict.key_type", keyTypeLabel(keyType)),
@@ -90,6 +92,7 @@ func (t *tracedIndex) Lookup(
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
+	ctx = telemetry.LoggerWithSpanContext(ctx, span)
 
 	span.SetAttributes(
 		attribute.Int("llm_d.kv_cache.index.lookup.block_count", len(requestKeys)),

--- a/pkg/kvcache/traced_scorer.go
+++ b/pkg/kvcache/traced_scorer.go
@@ -47,10 +47,13 @@ func (t *tracedScorer) Score(
 	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
 ) (map[string]float64, error) {
 	tracer := telemetry.Tracer("llm-d-kv-cache/pkg/kvcache")
-	_, span := tracer.Start(ctx, "llm_d.kv_cache.scorer.compute",
+	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.scorer.compute",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
+
+	// Correlate logs emitted by the wrapped scorer with this span.
+	ctx = telemetry.LoggerWithSpanContext(ctx, span)
 
 	span.SetAttributes(
 		attribute.String("llm_d.kv_cache.scorer.algorithm", string(t.next.Strategy())),

--- a/pkg/telemetry/logging.go
+++ b/pkg/telemetry/logging.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// LogKeyTraceID is the structured-log field carrying the active trace ID.
+	// It matches the W3C trace-context identifier used across the llm-d stack
+	// so logs from EPP, IPP, the sidecar, and kv-cache can be queried uniformly.
+	LogKeyTraceID = "trace_id"
+
+	// LogKeySpanID is the structured-log field carrying the active span ID.
+	LogKeySpanID = "span_id"
+)
+
+// LoggerWithSpanContext enriches the logger stored in ctx with the trace_id and
+// span_id of span, returning a context that carries the enriched logger.
+//
+// Call it immediately after starting a span. Downstream code that retrieves the
+// logger via log.FromContext then emits log lines tagged with the active trace,
+// so logs and traces can be correlated by trace_id. Because the span_id reflects
+// the span just started, log lines belong to the kv-cache span that produced
+// them rather than to a parent span injected further up the call chain.
+//
+// If span has no valid span context — tracing is disabled, the span was not
+// sampled, or it is a no-op span — ctx is returned unchanged.
+func LoggerWithSpanContext(ctx context.Context, span trace.Span) context.Context {
+	sc := span.SpanContext()
+	if !sc.IsValid() {
+		return ctx
+	}
+
+	logger := log.FromContext(ctx).WithValues(
+		LogKeyTraceID, sc.TraceID().String(),
+		LogKeySpanID, sc.SpanID().String(),
+	)
+	return log.IntoContext(ctx, logger)
+}

--- a/pkg/telemetry/logging_test.go
+++ b/pkg/telemetry/logging_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package telemetry_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/telemetry"
+)
+
+// captureLogger returns a logr.Logger that appends every emitted record's
+// formatted key/values to *out, so tests can assert on what was logged.
+func captureLogger(out *[]string) logr.Logger {
+	return funcr.New(func(_, args string) {
+		*out = append(*out, args)
+	}, funcr.Options{})
+}
+
+// startSampledSpan starts a real, always-sampled span so its span context is
+// valid (a no-op span would report IsValid() == false).
+func startSampledSpan(t *testing.T, ctx context.Context) (context.Context, trace.Span) {
+	t.Helper()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	otel.SetTracerProvider(tp)
+	return telemetry.Tracer().Start(ctx, "test")
+}
+
+func TestLoggerWithSpanContextInjectsFields(t *testing.T) {
+	var logged []string
+	ctx := log.IntoContext(context.Background(), captureLogger(&logged))
+
+	ctx, span := startSampledSpan(t, ctx)
+	defer span.End()
+
+	sc := span.SpanContext()
+	if !sc.IsValid() {
+		t.Fatal("expected a valid span context for the sampled span")
+	}
+
+	ctx = telemetry.LoggerWithSpanContext(ctx, span)
+	log.FromContext(ctx).Info("hello")
+
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 log record, got %d", len(logged))
+	}
+	rec := logged[0]
+	if !strings.Contains(rec, telemetry.LogKeyTraceID) || !strings.Contains(rec, sc.TraceID().String()) {
+		t.Errorf("log record missing trace_id: %q", rec)
+	}
+	if !strings.Contains(rec, telemetry.LogKeySpanID) || !strings.Contains(rec, sc.SpanID().String()) {
+		t.Errorf("log record missing span_id: %q", rec)
+	}
+}
+
+func TestLoggerWithSpanContextNoopForInvalidSpan(t *testing.T) {
+	var logged []string
+	ctx := log.IntoContext(context.Background(), captureLogger(&logged))
+
+	// A span from the default no-op tracer has an invalid span context.
+	otel.SetTracerProvider(trace.NewNoopTracerProvider())
+	ctx2, span := otel.Tracer("test").Start(ctx, "noop")
+	defer span.End()
+
+	if span.SpanContext().IsValid() {
+		t.Skip("tracer unexpectedly produced a valid span context")
+	}
+
+	got := telemetry.LoggerWithSpanContext(ctx2, span)
+
+	log.FromContext(got).Info("hello")
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 log record, got %d", len(logged))
+	}
+	if strings.Contains(logged[0], telemetry.LogKeyTraceID) || strings.Contains(logged[0], telemetry.LogKeySpanID) {
+		t.Errorf("expected no correlation fields for invalid span, got: %q", logged[0])
+	}
+}

--- a/pkg/telemetry/logging_test.go
+++ b/pkg/telemetry/logging_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/telemetry"
@@ -80,7 +81,7 @@ func TestLoggerWithSpanContextNoopForInvalidSpan(t *testing.T) {
 	ctx := log.IntoContext(context.Background(), captureLogger(&logged))
 
 	// A span from the default no-op tracer has an invalid span context.
-	otel.SetTracerProvider(trace.NewNoopTracerProvider())
+	otel.SetTracerProvider(noop.NewTracerProvider())
 	ctx2, span := otel.Tracer("test").Start(ctx, "noop")
 	defer span.End()
 


### PR DESCRIPTION
## What
Adds log–trace correlation to kv-cache. Introduces `telemetry.LoggerWithSpanContext(ctx, span)`, which injects the active span's `trace_id`/`span_id` into the context logger, and calls it at the three span boundaries:
- `Indexer.ScoreTokens` (`pkg/kvcache/indexer.go`)
- `tracedScorer.Score` (`pkg/kvcache/traced_scorer.go`)
- `tracedIndex.{Add,Evict,Lookup}` (`pkg/kvcache/kvblock/traced_index.go`)

Downstream code already reads the logger from context, so enriching at the span boundaries covers the index/scorer implementations with no further changes. The helper is a no-op when the span context is invalid (tracing off or span unsampled).

## Why
Without this, debugging a lookup or cache-hit score means manually matching timestamps between the trace backend and logs. This aligns kv-cache with the cross-component standardization in llm-d-router#1630.

Fixes #665

## Notes 
- Field names are `trace_id`/`span_id` per this issue's snippet. If llm-d-router#1630 settles on different keys, this should follow it.
- kvevents spans (#644/#639) don't exist yet; they should reuse this helper when they land.
