### PR TITLE
Trace tokenization and propagate request context

### DIFF
--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -151,7 +151,7 @@ func (k *Indexer) ComputeBlockKeys(ctx context.Context, renderReq *types.RenderC
 	}
 
 	// 1. tokenize prompt
-	tokens, features := k.tokenizersPool.Tokenize(renderReq, prompt)
+	tokens, features := k.tokenizersPool.Tokenize(ctx, renderReq, prompt)
 
 	// 2. Truncate prompt (if set in the request)
 	if renderReq != nil && renderReq.TruncatePromptTokens != nil {
@@ -207,7 +207,7 @@ func (k *Indexer) GetPodScores(ctx context.Context, renderReq *types.RenderChatR
 	}
 
 	// 1. tokenize prompt
-	tokens, features := k.tokenizersPool.Tokenize(renderReq, prompt)
+	tokens, features := k.tokenizersPool.Tokenize(ctx, renderReq, prompt)
 
 	// 2. Truncate prompt (if set in the request)
 	if renderReq != nil && renderReq.TruncatePromptTokens != nil {

--- a/pkg/kvcache/indexer_test.go
+++ b/pkg/kvcache/indexer_test.go
@@ -55,7 +55,9 @@ type mockTokenizersPool struct {
 	tokens []uint32
 }
 
-func (m *mockTokenizersPool) Tokenize(_ *types.RenderChatRequest, _ string) ([]uint32, *tokenization.MultiModalFeatures) {
+func (m *mockTokenizersPool) Tokenize(
+	_ context.Context, _ *types.RenderChatRequest, _ string,
+) ([]uint32, *tokenization.MultiModalFeatures) {
 	return m.tokens, nil
 }
 

--- a/pkg/kvcache/types.go
+++ b/pkg/kvcache/types.go
@@ -25,7 +25,8 @@ import (
 
 // TokenizersPool abstracts the tokenization pool for testability/mocking.
 type TokenizersPool interface {
-	Tokenize(renderReq *types.RenderChatRequest, prompt string) ([]uint32, *tokenization.MultiModalFeatures)
+	Tokenize(ctx context.Context, renderReq *types.RenderChatRequest, prompt string,
+	) ([]uint32, *tokenization.MultiModalFeatures)
 	Run(ctx context.Context)
 	SetTokenizer(tokenizer tokenization.Tokenizer, modelName string)
 }

--- a/pkg/tokenization/pool.go
+++ b/pkg/tokenization/pool.go
@@ -20,9 +20,13 @@ import (
 	"context"
 	"sync"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/llm-d/llm-d-kv-cache/pkg/telemetry"
 	types "github.com/llm-d/llm-d-kv-cache/pkg/tokenization/types"
 )
 
@@ -38,6 +42,10 @@ type tokenizationResponse struct {
 
 // Task represents a unit of work for tokenizing a prompt.
 type Task struct {
+	// Ctx carries the caller's trace context across the worker-queue boundary
+	// so the tokenization span is parented to the originating request span.
+	// A nil Ctx is treated as context.Background().
+	Ctx       context.Context
 	RenderReq *types.RenderChatRequest
 	Prompt    string
 	ModelName string
@@ -62,17 +70,23 @@ type Pool struct {
 
 // EnqueueTokenization enqueues a new tokenization task.
 // This method only enqueues the task and does not start processing it.
-func (pool *Pool) EnqueueTokenization(prompt string) {
+func (pool *Pool) EnqueueTokenization(ctx context.Context, prompt string) {
 	task := Task{
+		Ctx:    ctx,
 		Prompt: prompt,
 	}
 	pool.queue.Add(task)
 }
 
 // Tokenize queues a task and blocks until the final result is available.
-func (pool *Pool) Tokenize(renderReq *types.RenderChatRequest, prompt string) ([]uint32, *MultiModalFeatures) {
+// ctx is propagated to the worker so the tokenization span links to the
+// caller's request span.
+func (pool *Pool) Tokenize(
+	ctx context.Context, renderReq *types.RenderChatRequest, prompt string,
+) ([]uint32, *MultiModalFeatures) {
 	resultCh := make(chan tokenizationResponse, 1)
 	pool.queue.Add(Task{
+		Ctx:       ctx,
 		RenderReq: renderReq,
 		Prompt:    prompt,
 		ResultCh:  resultCh,
@@ -132,22 +146,50 @@ func (pool *Pool) workerLoop(_ int) {
 // processTask tokenizes the prompt and returns the tokens via ResultCh.
 // It sends exactly one response (success or error) if ResultCh is provided.
 func (pool *Pool) processTask(task Task) error {
+	// Resume the caller's trace context across the worker-queue boundary so the
+	// tokenization span is parented to the originating request span. When tracing
+	// is not configured, otel.Tracer() returns a no-op implementation.
+	ctx := task.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	mode := "text"
+	if task.RenderReq != nil {
+		mode = "chat"
+	}
+	_, span := telemetry.Tracer("llm-d-kv-cache/pkg/tokenization").Start(
+		ctx, "llm_d.kv_cache.tokenization",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("llm_d.kv_cache.tokenization.mode", mode),
+		attribute.Int("llm_d.kv_cache.tokenization.prompt_length", len(task.Prompt)),
+	)
+
 	var tokens []uint32
 	var features *MultiModalFeatures
 	var err error
 	if task.RenderReq == nil {
 		tokens, _, err = pool.tokenizer.Render(task.Prompt)
 		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
 			log.Log.Error(err, "failed to render tokens", "prompt", task.Prompt)
 			return err
 		}
 	} else {
 		tokens, features, err = pool.tokenizer.RenderChat(task.RenderReq)
 		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
 			log.Log.Error(err, "failed to render tokens", "task", task.RenderReq)
 			return err
 		}
 	}
+
+	span.SetAttributes(
+		attribute.Int("llm_d.kv_cache.tokenization.token_count", len(tokens)),
+		attribute.Bool("llm_d.kv_cache.tokenization.multimodal", features != nil),
+	)
 
 	// On success, send the response if a channel is provided and close the channel.
 	if task.ResultCh != nil {

--- a/pkg/tokenization/pool.go
+++ b/pkg/tokenization/pool.go
@@ -70,9 +70,8 @@ type Pool struct {
 
 // EnqueueTokenization enqueues a new tokenization task.
 // This method only enqueues the task and does not start processing it.
-func (pool *Pool) EnqueueTokenization(ctx context.Context, prompt string) {
+func (pool *Pool) EnqueueTokenization(prompt string) {
 	task := Task{
-		Ctx:    ctx,
 		Prompt: prompt,
 	}
 	pool.queue.Add(task)
@@ -148,14 +147,16 @@ func (pool *Pool) workerLoop(_ int) {
 func (pool *Pool) processTask(task Task) error {
 	// Resume the caller's trace context across the worker-queue boundary so the
 	// tokenization span is parented to the originating request span. When tracing
-	// is not configured, otel.Tracer() returns a no-op implementation.
+	// is not configured, telemetry.Tracer() returns a no-op implementation.
 	ctx := task.Ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	mode := "text"
+	promptLen := len(task.Prompt)
 	if task.RenderReq != nil {
 		mode = "chat"
+		promptLen = chatPromptLen(task.RenderReq)
 	}
 	_, span := telemetry.Tracer("llm-d-kv-cache/pkg/tokenization").Start(
 		ctx, "llm_d.kv_cache.tokenization",
@@ -164,7 +165,7 @@ func (pool *Pool) processTask(task Task) error {
 	defer span.End()
 	span.SetAttributes(
 		attribute.String("llm_d.kv_cache.tokenization.mode", mode),
-		attribute.Int("llm_d.kv_cache.tokenization.prompt_length", len(task.Prompt)),
+		attribute.Int("llm_d.kv_cache.tokenization.prompt_length", promptLen),
 	)
 
 	var tokens []uint32
@@ -202,6 +203,20 @@ func (pool *Pool) processTask(task Task) error {
 	}
 
 	return nil
+}
+
+// chatPromptLen returns the combined character length of the conversation's
+// text content. It is used as an approximate prompt size for chat-mode
+// tokenization spans, where task.Prompt is empty.
+func chatPromptLen(req *types.RenderChatRequest) int {
+	if req == nil {
+		return 0
+	}
+	total := 0
+	for _, msg := range req.Conversation {
+		total += len(msg.Content.PlainText())
+	}
+	return total
 }
 
 func (pool *Pool) SetTokenizer(tokenizer Tokenizer, modelName string) {

--- a/pkg/tokenization/pool_trace_test.go
+++ b/pkg/tokenization/pool_trace_test.go
@@ -66,7 +66,12 @@ func TestProcessTaskSpanChatModeAndMultimodal(t *testing.T) {
 	mockTokenizer := &MockTokenizer{}
 	pool := &Pool{modelName: "test-model", workers: 1, tokenizer: mockTokenizer}
 
-	renderReq := &types.RenderChatRequest{}
+	renderReq := &types.RenderChatRequest{
+		Conversation: []types.Conversation{
+			{Role: "system", Content: types.Content{Raw: "You are helpful."}},
+			{Role: "user", Content: types.Content{Raw: "Hello there!"}},
+		},
+	}
 	features := &MultiModalFeatures{MMHashes: map[string][]string{"image": {"abc"}}}
 	mockTokenizer.On("RenderChat", renderReq).Return([]uint32{1, 2}, features, nil)
 
@@ -76,6 +81,9 @@ func TestProcessTaskSpanChatModeAndMultimodal(t *testing.T) {
 	attrs := tokenizationSpanAttributes(span)
 	require.Equal(t, "chat", attrs["llm_d.kv_cache.tokenization.mode"].AsString())
 	require.True(t, attrs["llm_d.kv_cache.tokenization.multimodal"].AsBool())
+	// prompt_length reflects chat content length, not the empty task.Prompt.
+	require.Equal(t, int64(len("You are helpful.")+len("Hello there!")),
+		attrs["llm_d.kv_cache.tokenization.prompt_length"].AsInt64())
 	mockTokenizer.AssertExpectations(t)
 }
 

--- a/pkg/tokenization/pool_trace_test.go
+++ b/pkg/tokenization/pool_trace_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenization
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	types "github.com/llm-d/llm-d-kv-cache/pkg/tokenization/types"
+)
+
+func TestProcessTaskSpanParentedToRequest(t *testing.T) {
+	recorder := setupTokenizationSpanRecorder(t)
+
+	mockTokenizer := &MockTokenizer{}
+	pool := &Pool{modelName: "test-model", workers: 1, tokenizer: mockTokenizer}
+
+	expectedTokens := []uint32{1, 2, 3, 4}
+	mockTokenizer.On("Render", "hello world").Return(expectedTokens, []types.Offset(nil), nil)
+
+	// Establish a parent request span and propagate it through the task context.
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "request")
+	task := Task{Ctx: ctx, Prompt: "hello world"}
+
+	require.NoError(t, pool.processTask(task))
+	parent.End()
+
+	span := spanByNameTokenization(t, recorder.Ended(), "llm_d.kv_cache.tokenization")
+	// The tokenization span must be a child of the request span.
+	require.Equal(t, parent.SpanContext().TraceID(), span.SpanContext().TraceID())
+	require.Equal(t, parent.SpanContext().SpanID(), span.Parent().SpanID())
+
+	attrs := tokenizationSpanAttributes(span)
+	require.Equal(t, "text", attrs["llm_d.kv_cache.tokenization.mode"].AsString())
+	require.Equal(t, int64(len("hello world")), attrs["llm_d.kv_cache.tokenization.prompt_length"].AsInt64())
+	require.Equal(t, int64(len(expectedTokens)), attrs["llm_d.kv_cache.tokenization.token_count"].AsInt64())
+	require.False(t, attrs["llm_d.kv_cache.tokenization.multimodal"].AsBool())
+	mockTokenizer.AssertExpectations(t)
+}
+
+func TestProcessTaskSpanChatModeAndMultimodal(t *testing.T) {
+	recorder := setupTokenizationSpanRecorder(t)
+
+	mockTokenizer := &MockTokenizer{}
+	pool := &Pool{modelName: "test-model", workers: 1, tokenizer: mockTokenizer}
+
+	renderReq := &types.RenderChatRequest{}
+	features := &MultiModalFeatures{MMHashes: map[string][]string{"image": {"abc"}}}
+	mockTokenizer.On("RenderChat", renderReq).Return([]uint32{1, 2}, features, nil)
+
+	require.NoError(t, pool.processTask(Task{RenderReq: renderReq, Prompt: ""}))
+
+	span := spanByNameTokenization(t, recorder.Ended(), "llm_d.kv_cache.tokenization")
+	attrs := tokenizationSpanAttributes(span)
+	require.Equal(t, "chat", attrs["llm_d.kv_cache.tokenization.mode"].AsString())
+	require.True(t, attrs["llm_d.kv_cache.tokenization.multimodal"].AsBool())
+	mockTokenizer.AssertExpectations(t)
+}
+
+func TestProcessTaskSpanRecordsError(t *testing.T) {
+	recorder := setupTokenizationSpanRecorder(t)
+
+	mockTokenizer := &MockTokenizer{}
+	pool := &Pool{modelName: "test-model", workers: 1, tokenizer: mockTokenizer}
+
+	renderErr := errors.New("render failed")
+	mockTokenizer.On("Render", "boom").Return(nil, []types.Offset(nil), renderErr)
+
+	err := pool.processTask(Task{Prompt: "boom"})
+	require.ErrorIs(t, err, renderErr)
+
+	span := spanByNameTokenization(t, recorder.Ended(), "llm_d.kv_cache.tokenization")
+	require.Equal(t, codes.Error, span.Status().Code)
+	require.Equal(t, renderErr.Error(), span.Status().Description)
+}
+
+func setupTokenizationSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+
+	return recorder
+}
+
+func spanByNameTokenization(t *testing.T, spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	for _, span := range spans {
+		if span.Name() == name {
+			return span
+		}
+	}
+
+	require.Failf(t, "missing span", "span %q not found", name)
+	return nil
+}
+
+func tokenizationSpanAttributes(span sdktrace.ReadOnlySpan) map[string]attribute.Value {
+	attrs := make(map[string]attribute.Value)
+	for _, attr := range span.Attributes() {
+		attrs[string(attr.Key)] = attr.Value
+	}
+	return attrs
+}


### PR DESCRIPTION
Part of #644 ("Extend OTel Tracing Coverage: kvevents + tokenization"). This PR covers the **tokenization** sub-task
only; the **kvevents** event-processing span is handled separately in #678

@gyliu513 