### PR TITLE
refactor(tokenization): drop dead offsets return from Render

### DIFF
--- a/pkg/tokenization/pool.go
+++ b/pkg/tokenization/pool.go
@@ -136,7 +136,7 @@ func (pool *Pool) processTask(task Task) error {
 	var features *MultiModalFeatures
 	var err error
 	if task.RenderReq == nil {
-		tokens, _, err = pool.tokenizer.Render(task.Prompt)
+		tokens, err = pool.tokenizer.Render(task.Prompt)
 		if err != nil {
 			log.Log.Error(err, "failed to render tokens", "prompt", task.Prompt)
 			return err

--- a/pkg/tokenization/pool_test.go
+++ b/pkg/tokenization/pool_test.go
@@ -47,23 +47,16 @@ func (m *MockTokenizer) RenderChat(renderReq *types.RenderChatRequest) ([]uint32
 	return tokens, features, args.Error(2)
 }
 
-func (m *MockTokenizer) Render(prompt string) ([]uint32, []types.Offset, error) {
+func (m *MockTokenizer) Render(prompt string) ([]uint32, error) {
 	args := m.Called(prompt)
 	if args.Get(0) == nil {
-		return nil, nil, args.Error(2)
+		return nil, args.Error(1)
 	}
 	tokens, ok := args.Get(0).([]uint32)
 	if !ok {
 		panic("MockTokenizer.Render: expected []uint32")
 	}
-	if args.Get(1) == nil {
-		return tokens, nil, args.Error(2)
-	}
-	offsets, ok := args.Get(1).([]types.Offset)
-	if !ok {
-		panic("MockTokenizer.Render: expected []types.Offset")
-	}
-	return tokens, offsets, args.Error(2)
+	return tokens, args.Error(1)
 }
 
 func (m *MockTokenizer) Close() error {
@@ -89,10 +82,9 @@ func TestPool_ProcessTask(t *testing.T) {
 
 	// Setup specific mock return values
 	expectedTokens := []uint32{12345, 67890, 11111}
-	expectedOffsets := []types.Offset{{0, 5}, {6, 11}}
 
 	mockTokenizer.On("Render", task.Prompt).
-		Return(expectedTokens, expectedOffsets, nil)
+		Return(expectedTokens, nil)
 
 	// Execute
 	err := pool.processTask(task)
@@ -111,7 +103,7 @@ func TestPool_WorkerLoop(t *testing.T) {
 		"successful task processing": {
 			setupMocks: func(mt *MockTokenizer) {
 				mt.On("Render", "test prompt").
-					Return([]uint32{1, 2, 3}, []types.Offset{{0, 4}}, nil)
+					Return([]uint32{1, 2, 3}, nil)
 			},
 			genTasks: func() ([]Task, chan tokenizationResponse) {
 				return []Task{{Prompt: "test prompt"}}, nil
@@ -121,7 +113,7 @@ func TestPool_WorkerLoop(t *testing.T) {
 		"task with result channel": {
 			setupMocks: func(mt *MockTokenizer) {
 				mt.On("Render", "test with channel").
-					Return([]uint32{10, 20, 30}, []types.Offset{{0, 4}}, nil)
+					Return([]uint32{10, 20, 30}, nil)
 			},
 			genTasks: func() ([]Task, chan tokenizationResponse) {
 				ch := make(chan tokenizationResponse, 1)
@@ -152,10 +144,9 @@ func TestPool_WorkerLoop(t *testing.T) {
 				for i := range 5 {
 					prompt := "prompt " + string(rune('a'+i))
 					tokens := []uint32{uint32(i), uint32(i + 1)} //nolint:gosec // test code
-					offsets := []types.Offset{{0, 6}}
 
 					mt.On("Render", prompt).
-						Return(tokens, offsets, nil).Once()
+						Return(tokens, nil).Once()
 				}
 			},
 			genTasks: func() ([]Task, chan tokenizationResponse) {
@@ -176,7 +167,7 @@ func TestPool_WorkerLoop(t *testing.T) {
 			setupMocks: func(mt *MockTokenizer) {
 				// Mock will fail every time, causing retries
 				mt.On("Render", "failing prompt").Return(
-					[]uint32(nil), []types.Offset(nil), assert.AnError)
+					[]uint32(nil), assert.AnError)
 			},
 			genTasks: func() ([]Task, chan tokenizationResponse) {
 				ch := make(chan tokenizationResponse, 1)

--- a/pkg/tokenization/tokenizer.go
+++ b/pkg/tokenization/tokenizer.go
@@ -33,6 +33,6 @@ type MultiModalFeatures struct {
 // Tokenizer interface defines the methods for tokenization.
 type Tokenizer interface {
 	RenderChat(*types.RenderChatRequest) ([]uint32, *MultiModalFeatures, error)
-	Render(string) ([]uint32, []types.Offset, error)
+	Render(string) ([]uint32, error)
 	Type() string
 }

--- a/pkg/tokenization/uds_tokenizer.go
+++ b/pkg/tokenization/uds_tokenizer.go
@@ -215,8 +215,9 @@ func (u *UdsTokenizer) warmup(ctx context.Context) {
 
 func strPtr(s string) *string { return &s }
 
-// Render tokenizes a plain-text prompt via the UDS renderer service.
-func (u *UdsTokenizer) Render(prompt string) ([]uint32, []types.Offset, error) {
+// Render tokenizes a plain-text prompt via the UDS renderer service and returns
+// the token IDs. The renderer service does not produce token offsets.
+func (u *UdsTokenizer) Render(prompt string) ([]uint32, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
@@ -225,14 +226,14 @@ func (u *UdsTokenizer) Render(prompt string) ([]uint32, []types.Offset, error) {
 		Prompt:    prompt,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("gRPC RenderCompletion request failed: %w", err)
+		return nil, fmt.Errorf("gRPC RenderCompletion request failed: %w", err)
 	}
 
 	if !resp.Success {
-		return nil, nil, fmt.Errorf("render completion failed: %s", resp.ErrorMessage)
+		return nil, fmt.Errorf("render completion failed: %s", resp.ErrorMessage)
 	}
 
-	return resp.TokenIds, nil, nil
+	return resp.TokenIds, nil
 }
 
 // Encode tokenizes the input string and returns the token IDs and offsets.

--- a/pkg/tokenization/uds_tokenizer_test.go
+++ b/pkg/tokenization/uds_tokenizer_test.go
@@ -295,10 +295,9 @@ func (s *UdsTokenizerTestSuite) TestUdsTokenizer_ModelNotInMap() {
 
 func (s *UdsTokenizerTestSuite) TestUdsTokenizer_Render() {
 	input := "hello world"
-	tokens, offsets, err := s.tokenizer.Render(input)
+	tokens, err := s.tokenizer.Render(input)
 	s.Require().NoError(err)
 	s.Assert().Equal(len([]rune(input)), len(tokens))
-	s.Assert().Nil(offsets, "RenderCompletion does not return character offsets")
 
 	// Verify specific characters (mock converts runes to token IDs)
 	s.Assert().Equal(uint32('h'), tokens[0])
@@ -365,7 +364,7 @@ func (s *UdsTokenizerTestSuite) TestUdsTokenizer_Type() {
 func (s *UdsTokenizerTestSuite) TestUdsTokenizer_TokenizeError() {
 	s.mockServer.tokenizeError = true
 
-	_, _, err := s.tokenizer.Render("test")
+	_, err := s.tokenizer.Render("test")
 	s.Assert().Error(err)
 	s.Assert().Contains(err.Error(), "render completion failed")
 }

--- a/tests/e2e/uds_tokenizer/uds_e2e_test.go
+++ b/tests/e2e/uds_tokenizer/uds_e2e_test.go
@@ -34,13 +34,13 @@ import (
 func (s *UDSTokenizerSuite) TestTokenize() {
 	prompt := "What is the capital of France?"
 
-	tokens1, _, err := s.tokenizer.Render(prompt)
+	tokens1, err := s.tokenizer.Render(prompt)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(tokens1, "token IDs should not be empty")
 	s.T().Logf("Tokenized %d tokens for prompt", len(tokens1))
 
 	// Tokenize the same prompt again — results must be identical (determinism).
-	tokens2, _, err := s.tokenizer.Render(prompt)
+	tokens2, err := s.tokenizer.Render(prompt)
 	s.Require().NoError(err)
 	s.Require().Equal(tokens1, tokens2, "repeated tokenization should be deterministic (token IDs)")
 }
@@ -375,7 +375,7 @@ var (
 // the exact expected token IDs. If golden values are not yet set, the test
 // logs the actual values in Go source format and skips.
 func (s *UDSTokenizerSuite) TestGoldenTokenization() {
-	tokens, _, err := s.tokenizer.Render(goldenPrompt)
+	tokens, err := s.tokenizer.Render(goldenPrompt)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(tokens)
 
@@ -393,7 +393,7 @@ func (s *UDSTokenizerSuite) TestGoldenTokenization() {
 // TestGoldenBlockKeys verifies that computing block keys from fixed tokens
 // produces the exact expected request keys.
 func (s *UDSTokenizerSuite) TestGoldenBlockKeys() {
-	tokens, _, err := s.tokenizer.Render(goldenPrompt)
+	tokens, err := s.tokenizer.Render(goldenPrompt)
 	s.Require().NoError(err)
 
 	requestKeys, err := s.tokenProcessor.TokensToKVBlockKeys(
@@ -436,7 +436,7 @@ func (s *UDSTokenizerSuite) TestGoldenChatTokenization() {
 // TestGoldenScoring verifies the full pipeline: tokenize → block keys → index → score.
 // Uses deterministic inputs and verifies the exact score value.
 func (s *UDSTokenizerSuite) TestGoldenScoring() {
-	tokens, _, err := s.tokenizer.Render(goldenPrompt)
+	tokens, err := s.tokenizer.Render(goldenPrompt)
 	s.Require().NoError(err)
 
 	engineKeys, requestKeys := s.promptToEngineAndRequestKeys(tokens)
@@ -464,7 +464,7 @@ func (s *UDSTokenizerSuite) TestCacheHit() {
 	prompt := "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 	fakePodList := []string{s.Pod1IP}
 
-	tokens, _, err := s.tokenizer.Render(prompt)
+	tokens, err := s.tokenizer.Render(prompt)
 	s.Require().NoError(err)
 
 	engineKeys, requestKeys := s.promptToEngineAndRequestKeys(tokens)
@@ -498,7 +498,7 @@ func (s *UDSTokenizerSuite) TestPrefixReduction() {
 	midPrompt := "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 	shortPrompt := "lorem ipsum dolor sit amet, consectetur adipiscing elit."
 
-	tokens, _, err := s.tokenizer.Render(fullPrompt)
+	tokens, err := s.tokenizer.Render(fullPrompt)
 	s.Require().NoError(err)
 
 	fullEngineKeys, fullRequestKeys := s.promptToEngineAndRequestKeys(tokens)
@@ -524,7 +524,7 @@ func (s *UDSTokenizerSuite) TestPrefixReduction() {
 	s.T().Logf("Short prompt scores: %+v", pods)
 
 	// Verify the short prompt score equals the number of its block keys.
-	shortTokens, _, err := s.tokenizer.Render(shortPrompt)
+	shortTokens, err := s.tokenizer.Render(shortPrompt)
 	s.Require().NoError(err)
 	_, shortRequestKeys := s.promptToEngineAndRequestKeys(shortTokens)
 	s.Equal(int(pods[s.Pod1IP]), len(shortRequestKeys),
@@ -580,7 +580,7 @@ func (s *UDSTokenizerSuite) TestScoreTokensCacheHit() {
 	prompt := "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 	fakePodList := []string{s.Pod1IP}
 
-	tokens, _, err := s.tokenizer.Render(prompt)
+	tokens, err := s.tokenizer.Render(prompt)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(tokens)
 
@@ -600,7 +600,7 @@ func (s *UDSTokenizerSuite) TestScoreTokensCacheMiss() {
 	prompt := "What is the capital of France?"
 	fakePodList := []string{s.Pod1IP}
 
-	tokens, _, err := s.tokenizer.Render(prompt)
+	tokens, err := s.tokenizer.Render(prompt)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(tokens)
 
@@ -618,7 +618,7 @@ func (s *UDSTokenizerSuite) TestScoreTokensConsistentWithGetPodScores() {
 	prompt := "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 	fakePodList := []string{s.Pod1IP}
 
-	tokens, _, err := s.tokenizer.Render(prompt)
+	tokens, err := s.tokenizer.Render(prompt)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(tokens)
 
@@ -644,7 +644,7 @@ func (s *UDSTokenizerSuite) TestScoreTokensPrefixReduction() {
 	fullPrompt := "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
 	shortPrompt := "lorem ipsum dolor sit amet, consectetur adipiscing elit."
 
-	fullTokens, _, err := s.tokenizer.Render(fullPrompt)
+	fullTokens, err := s.tokenizer.Render(fullPrompt)
 	s.Require().NoError(err)
 
 	fullEngineKeys, fullRequestKeys := s.promptToEngineAndRequestKeys(fullTokens)
@@ -652,7 +652,7 @@ func (s *UDSTokenizerSuite) TestScoreTokensPrefixReduction() {
 	s.addEntriesToIndex(fullEngineKeys, fullRequestKeys, fakePodList)
 
 	// Query with the short prompt's tokens — should produce a partial match.
-	shortTokens, _, err := s.tokenizer.Render(shortPrompt)
+	shortTokens, err := s.tokenizer.Render(shortPrompt)
 	s.Require().NoError(err)
 
 	pods, err := s.indexer.ScoreTokens(s.T().Context(), shortTokens, defaultModelName, fakePodList, nil)


### PR DESCRIPTION
## What

Removes the `[]types.Offset` return value from the `Tokenizer.Render(string)` interface method and its implementation.

## Why

Since the move to the renderer service (`RenderChatCompletion` RPC), `Render` has always returned a `nil` offset slice — the underlying `RenderCompletion` RPC doesn't produce character offsets. Every caller already throws it away with `_`, so the return value is dead weight that just makes the signature noisier and invites confusion about whether offsets are ever populated.

Closes #462.

## Changes

- Interface `Tokenizer.Render` is now `Render(string) ([]uint32, error)`.
- `UdsTokenizer.Render` drops the always-`nil` offset return; doc comment updated to note the renderer service doesn't produce offsets.
- Updated the single production caller (`pool.go`), the `MockTokenizer`, and the unit + e2e tests.

`Encode` is intentionally left alone — it still returns real offsets from the `Tokenize` RPC and the e2e tests assert on them.

## Testing

- `go build ./...` and `go vet ./...` clean
- `gofmt -l` clean
- `go test ./pkg/tokenization/...` passes

No behavior change — this is a pure signature cleanup.