### PR TITLE
feat(fs_backend): add empty metrics interface framework for future FS-specific metrics

### DIFF
--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -14,6 +14,7 @@
 
 import os
 from collections.abc import Collection
+from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
 from vllm.v1.kv_offload.base import (
@@ -25,6 +26,11 @@ from vllm.v1.kv_offload.base import (
     RequestOffloadingContext,
     get_offload_block_hash,
 )
+
+if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+        OffloadingConnectorStats,
+    )
 from zmq import ZMQError
 
 from llmd_fs_backend.event_publisher import StorageMedium
@@ -166,6 +172,45 @@ class SharedStorageOffloadingManager(OffloadingManager):
         """
         if success:
             self._publish_blocks_stored(keys)
+
+    def get_stats(self) -> "OffloadingConnectorStats | None":
+        """Return FS-backend-specific connector stats since the last call.
+
+        Compatibility note
+        ~~~~~~~~~~~~~~~~~~
+        get_stats() exists on vLLM's OffloadingManager base class but returns
+        None by default.  When running against vLLM v0.22.0, this method
+        overrides the base class default.  The scheduler calls it every step,
+        but since we return None the scheduler skips FS-backend-specific stats
+        (generic transfer metrics are still collected automatically by vLLM's
+        worker).
+
+        This is the counterpart to
+        SharedStorageOffloadingSpec.build_metric_definitions().
+        To add FS-specific metrics:
+
+        1. Declare the metrics in build_metric_definitions() (spec.py)
+        2. Accumulate data in the manager (e.g. lookup hit/miss counters)
+        3. Return the accumulated values here as OffloadingConnectorStats
+
+        Example::
+
+            stats = OffloadingConnectorStats()
+            stats.increase_counter("vllm:kv_offload_fs_lookup_hit", self._lookup_hits)
+            self._lookup_hits = 0
+            return stats
+
+        Currently returns None because this connector has no FS-specific
+        metrics.  Generic transfer metrics (load_bytes, store_bytes, etc.)
+        are automatically collected from TransferResult by the
+        OffloadingConnectorWorker and reported by the scheduler — they do
+        NOT go through this method.
+
+        See vllm-project/vllm#44008 and vllm-project/vllm#35669.
+        """
+        # Currently no FS-backend-specific stats to report.
+        # Returning None lets the scheduler skip this manager in get_stats().
+        return None
 
     def shutdown(self) -> None:
         if self._event_publisher is not None:

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/manager.py
@@ -178,12 +178,11 @@ class SharedStorageOffloadingManager(OffloadingManager):
 
         Compatibility note
         ~~~~~~~~~~~~~~~~~~
-        get_stats() exists on vLLM's OffloadingManager base class but returns
-        None by default.  When running against vLLM v0.22.0, this method
-        overrides the base class default.  The scheduler calls it every step,
-        but since we return None the scheduler skips FS-backend-specific stats
-        (generic transfer metrics are still collected automatically by vLLM's
-        worker).
+        get_stats() exists on vLLM's OffloadingManager base class and returns
+        None by default.  This method overrides that default.  The scheduler
+        calls it every step; since we return None, the scheduler skips
+        FS-backend-specific stats (generic transfer metrics are still
+        collected automatically by vLLM's worker).
 
         This is the counterpart to
         SharedStorageOffloadingSpec.build_metric_definitions().

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Iterator
+from typing import Any
 
 from vllm.config import VllmConfig
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -21,6 +22,7 @@ from vllm.v1.kv_offload.base import (
     GPULoadStoreSpec,
     LoadStoreSpec,
     OffloadingManager,
+    OffloadingMetricMetadata,
     OffloadingSpec,
 )
 from vllm.v1.kv_offload.worker.worker import OffloadingHandler
@@ -43,6 +45,47 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
     """
     OffloadingSpec for shared storage backend (e.g., mounted NFS, PVC).
     """
+
+    @classmethod
+    def build_metric_definitions(
+        cls, extra_config: dict[str, Any]
+    ) -> dict[str, OffloadingMetricMetadata]:
+        """Return Prometheus metric definitions for FS-backend-specific metrics.
+
+        Compatibility note
+        ~~~~~~~~~~~~~~~~~~
+        build_metric_definitions() was added to vLLM's OffloadingSpec base class
+        after v0.22.0 (in PR #35669).  When running against vLLM v0.22.0, this
+        method exists but is never called by OffloadPromMetrics — it is a no-op
+        placeholder that becomes functional once the vLLM dependency is upgraded.
+
+        Architecture
+        ~~~~~~~~~~~~
+        Generic transfer metrics (load_bytes, store_bytes, load_time, store_time,
+        load_size, store_size) are already declared by vLLM's
+        get_connector_metric_definitions() and automatically collected from
+        TransferResult by the OffloadingConnectorWorker.  This connector does NOT
+        re-declare them — doing so would be redundant and gets overwritten by
+        vLLM's definitions during OffloadPromMetrics initialisation:
+
+            self._offloading_metric_metadata = {
+                **spec_cls.build_metric_definitions(extra_config),
+                **get_connector_metric_definitions(),  # overwrites same-name keys
+            }
+
+        To add FS-specific metrics (e.g. lookup_hit/miss counters, file existence
+        check stats, GDS mode metrics), add entries here AND implement
+        SharedStorageOffloadingManager.get_stats() to return the actual values
+        via OffloadingConnectorStats.
+
+        See vllm-project/vllm#44008 (KV Offloading Metrics Redesign) and
+        vllm-project/vllm#35669 (Offloading Manager Stats) for the full
+        metrics architecture.
+        """
+        # Currently no FS-backend-specific metrics.
+        # Generic transfer metrics are handled by vLLM automatically.
+        # Future FS-specific metrics should be added here.
+        return {}
 
     def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
         # Hide "block_size" from the base class to bypass the uniformity

--- a/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
+++ b/kv_connectors/llmd_fs_backend/llmd_fs_backend/spec.py
@@ -54,10 +54,11 @@ class SharedStorageOffloadingSpec(OffloadingSpec):
 
         Compatibility note
         ~~~~~~~~~~~~~~~~~~
-        build_metric_definitions() was added to vLLM's OffloadingSpec base class
-        after v0.22.0 (in PR #35669).  When running against vLLM v0.22.0, this
-        method exists but is never called by OffloadPromMetrics — it is a no-op
-        placeholder that becomes functional once the vLLM dependency is upgraded.
+        build_metric_definitions() was added to vLLM's OffloadingSpec base
+        class after v0.23.0.  On vLLM >= that version, this method is called
+        by OffloadPromMetrics during startup to register FS-specific Prometheus
+        metrics.  Since we currently return {}, no FS-specific metrics are
+        registered — only vLLM's generic transfer metrics are active.
 
         Architecture
         ~~~~~~~~~~~~

--- a/kv_connectors/llmd_fs_backend/tests/test_spec.py
+++ b/kv_connectors/llmd_fs_backend/tests/test_spec.py
@@ -151,3 +151,32 @@ def test_scheduler_config_sees_offloaded_block_size(tmp_path):
             group_config.offloaded_block_size
             == spec.gpu_blocks_per_file * group_config.gpu_block_size
         )
+
+
+def test_build_metric_definitions_returns_empty_for_fs_specific_metrics():
+    """build_metric_definitions returns an empty dict because FS backend
+    currently has no FS-specific metrics to declare.
+
+    Generic transfer metrics (load_bytes, store_bytes, load_time, store_time,
+    load_size, store_size) are already declared by vLLM's
+    get_connector_metric_definitions() and automatically collected from
+    TransferResult by the OffloadingConnectorWorker.  Re-declaring them here
+    would be redundant — they get overwritten during OffloadPromMetrics init:
+
+        self._offloading_metric_metadata = {
+            **spec_cls.build_metric_definitions(extra_config),
+            **get_connector_metric_definitions(),  # ← overwrites同名 keys
+        }
+
+    To add FS-specific metrics in the future:
+    1. Add entries to the dict returned by build_metric_definitions()
+    2. Implement SharedStorageOffloadingManager.get_stats() to return
+       actual values via OffloadingConnectorStats
+
+    See vllm-project/vllm#44008 and vllm-project/vllm#35669.
+    """
+    extra_config: dict[str, object] = {}
+    defs = SharedStorageOffloadingSpec.build_metric_definitions(extra_config)
+
+    # No FS-specific metrics currently — generic transfer metrics are handled by vLLM.
+    assert defs == {}


### PR DESCRIPTION
## Summary

Add `build_metric_definitions()` and `get_stats()` to the FS backend as
empty placeholder interfaces for future FS-specific Prometheus metrics.

These methods form the framework that future contributors can follow when
adding FS-specific metrics (e.g. lookup hit/miss counters, file existence
check stats, GDS mode metrics).

## Background

vLLM #44008 (KV Offloading Metrics Redesign) introduced a two-layer metrics
architecture:
1. **Connector-generic metrics** (load_bytes, store_bytes, etc.) — declared
   by vLLM's `get_connector_metric_definitions()`, automatically collected
   from `TransferResult` by the OffloadingConnectorWorker
2. **Spec-specific metrics** — declared by each spec's
   `build_metric_definitions()`, returned by manager's `get_stats()`

This PR implements the FS backend side of layer 2 as empty placeholders
with detailed documentation explaining the architecture and how to extend it.

## Changes

| File | Change |
|------|--------|
| `spec.py` | Add `build_metric_definitions()` returning `{}` with docstring explaining why generic metrics should NOT be re-declared here |
| `manager.py` | Add `get_stats()` returning `None` with docstring explaining the two-step process for adding FS-specific metrics |
| `test_spec.py` | Test that verifies empty return and documents the context for future contributors |

## Compatibility

The FS backend was migrated to vLLM 0.23.0 in #666. `build_metric_definitions()`
was added to vLLM's OffloadingSpec base class after v0.23.0 (in PR #35669).
On vLLM versions that include it, this method is called by OffloadPromMetrics
during startup to register FS-specific Prometheus metrics. Since we currently
return `{}`, no FS-specific metrics are registered — only vLLM's generic
transfer metrics are active.

Both methods return the same values as the vLLM base class defaults, so there
is **no runtime behavior change**.

## Testing

### Current (done)
- **Unit test**: `test_spec.py` verifies `build_metric_definitions()` returns `{}`
- **Lint**: `ruff check` passes on all modified files
- **Syntax**: All Python files parse correctly

### Deployment verification (optional)
Since this PR does not change runtime behavior, deployment testing is optional.
To verify in a live vLLM + FS backend deployment:

1. Deploy vLLM with FS backend (see `docs/deployment/vllm-storage.yaml`)
2. Send requests to trigger KV offload
3. Check metrics endpoint:
   ```bash
   curl http://<vllm-pod>:8000/metrics | grep "vllm:kv_offload"
   ```
4. Confirm generic transfer metrics are present:
   - `vllm:kv_offload_load_bytes_total`
   - `vllm:kv_offload_store_bytes_total`
   - `vllm:kv_offload_load_time_seconds_total`
   - `vllm:kv_offload_store_time_seconds_total`
   - `vllm:kv_offload_load_size_bucket`
   - `vllm:kv_offload_store_size_bucket`

No FS-specific metrics should appear (as expected — the interface returns `{}`).

## Related

- llm-d issue #616: Track feature gaps — mentions per-job metrics should
  merge into vLLM #44008
- llm-d issue #529: Remove OffloadPromMetrics monkey-patch after vLLM upgrade
- vLLM #44008: KV Offloading Metrics Redesign
- vLLM #35669: Offloading Manager Stats