### PR TITLE
ci: wire fs_backend CPU-safe tests into GitHub CI

### DIFF
--- a/.github/workflows/ci-fs-backend.yaml
+++ b/.github/workflows/ci-fs-backend.yaml
@@ -1,0 +1,25 @@
+name: CI - FS Backend Test
+
+on:
+  pull_request:
+    paths:
+      - 'kv_connectors/llmd_fs_backend/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'kv_connectors/llmd_fs_backend/**'
+
+jobs:
+  cpu-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: kv_connectors/llmd_fs_backend
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pytest msgpack pyzmq
+      - run: pytest tests/cpu/ -v

--- a/kv_connectors/llmd_fs_backend/Makefile
+++ b/kv_connectors/llmd_fs_backend/Makefile
@@ -39,6 +39,10 @@ test:
 test-performance:
 	pytest ./tests/performance/ -v -sq
 
+# Run CPU-safe tests (no GPU required)
+test-cpu:
+	pytest ./tests/cpu/ -v
+
 # Clean local build artifacts
 clean:
 	rm -rf build dist *.egg-info $(WHEEL_DIR)

--- a/kv_connectors/llmd_fs_backend/tests/cpu/conftest.py
+++ b/kv_connectors/llmd_fs_backend/tests/cpu/conftest.py
@@ -1,0 +1,21 @@
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mark_cpu_tests(request):
+    """Mark all tests under tests/cpu/ as not requiring CUDA."""
+    request.node.add_marker(pytest.mark.no_cuda_required)


### PR DESCRIPTION
## What this PR does

Resolves #572 — wires fs_backend Python tests into GitHub CI so CPU-safe tests run on `ubuntu-latest` without GPU.

## Problem

`tests/conftest.py` has a session-level `require_cuda` fixture (autouse) that skips **all tests** when no GPU is available. Since GitHub CI runners have no GPU, zero fs_backend tests run in CI.

## Solution

Split CPU-safe tests from GPU-requiring tests using the existing `no_cuda_required` marker:

1. **`tests/cpu/conftest.py`** (new) — autouse fixture that auto-marks all tests under `tests/cpu/` with `no_cuda_required`, so they bypass the CUDA check
2. **`.github/workflows/ci-fs-backend.yaml`** (new) — runs `pytest tests/cpu/ -v` on PR/push when `kv_connectors/llmd_fs_backend/**` paths change
3. **`Makefile`** — adds `make test-cpu` target for local development

## Verification

All 13 tests in `tests/cpu/` pass locally without GPU:
- `test_hash_to_uint64_matches_file_mapper_lower_64_bits`
- `test_storage_event_publisher_emits_go_compatible_three_frame_message`
- `test_storage_event_publisher_sequence_and_close_are_idempotent`
- `test_shared_storage_manager_publishes_successful_stores_only`
- `test_shared_storage_manager_publish_errors_are_fail_open`
- `test_nixl_manager_publishes_and_preserves_dict_lookup_bookkeeping`
- `test_nixl_manager_does_not_publish_or_record_failed_stores`
- `test_publish_blocks_removed_emits_correct_event_format`
- `test_publish_blocks_removed_with_model_name_override`
- `test_publish_blocks_removed_empty_hashes_is_noop`
- `test_publisher_without_model_name`
- `test_publish_blocks_removed_uses_instance_topic_when_no_override`
- `test_publish_blocks_removed_masks_to_uint64`