### PR TITLE
docs(fs-backend): replace PR link with official vLLM KV offloading docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ graph TD
 * [**llmd-fs-backend**](kv_connectors/llmd_fs_backend/README.md):
   Storage backend for vLLM's `OffloadingConnector` — moves KV-cache blocks between GPU and shared storage (local disk, shared filesystem, or object store). Pre-built wheels are published via the project's pip index; see the connector README for install instructions and configuration.
   > [!IMPORTANT]
-  > **Now upstreamed into vLLM.** `llmd-fs-connector==0.23` (llm-d v0.8 / vLLM v0.23) is the **final release** — llmd-fs-backend is now the FS tier of vLLM's multi-tier offloading connector (`TieringOffloadingSpec`). All new features and support continue there; see the [vLLM KV offloading guide](https://github.com/vllm-project/vllm/pull/44415).
+  > **Now upstreamed into vLLM.** `llmd-fs-connector==0.23` (llm-d v0.8 / vLLM v0.23) is the **final release** — llmd-fs-backend is now the FS tier of vLLM's multi-tier offloading connector (`TieringOffloadingSpec`). All new features and support continue there; see the [vLLM KV offloading guide](https://docs.vllm.ai/en/latest/features/kv_offloading_usage/).
 

--- a/kv_connectors/llmd_fs_backend/README.md
+++ b/kv_connectors/llmd_fs_backend/README.md
@@ -7,7 +7,7 @@
 > **The filesystem offloading logic is now upstreamed into vLLM** as the FS tier of the
 > **multi-tier offloading connector** (`TieringOffloadingSpec`). All new features, fixes,
 > and support continue there. See the
-> [vLLM KV offloading guide](https://github.com/vllm-project/vllm/pull/44415).
+> [vLLM KV offloading guide](https://docs.vllm.ai/en/latest/features/kv_offloading_usage/).
 >
 > This repository remains available for the 0.23 release and earlier; the docs below
 > describe that final release.


### PR DESCRIPTION
## Summary
Replace the "vLLM KV offloading guide" link with the official docs page as requested in #655.

Per feedback from @kfirtoledo: https://github.com/llm-d/llm-d-kv-cache/issues/655#issuecomment-4824946011

## Changes
- `README.md`: link changed from PR #44415 to https://docs.vllm.ai/en/latest/features/kv_offloading_usage/
- `kv_connectors/llmd_fs_backend/README.md`: same link fix

Closes #655