### PR TITLE
fix(kvblock): stop Lookup at first prefix-chain break

### DIFF
--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -297,11 +297,12 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 
 			highestHitIdx = idx
 
+			var filteredPods []PodEntry
 			if podIdentifierSet.Len() == 0 {
 				// If no pod identifiers are provided, return all pods
 				pods.cache.Range(func(k, value interface{}) bool {
 					if pod, ok := k.(PodEntry); ok {
-						podsPerKey[key] = append(podsPerKey[key], pod)
+						filteredPods = append(filteredPods, pod)
 					}
 					return true
 				})
@@ -310,14 +311,21 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 				pods.cache.Range(func(k, value interface{}) bool {
 					if pod, ok := k.(PodEntry); ok {
 						if podIdentifierSet.Has(pod.PodIdentifier) {
-							podsPerKey[key] = append(podsPerKey[key], pod)
+							filteredPods = append(filteredPods, pod)
 						}
 					}
 					return true
 				})
 			}
+
+			if len(filteredPods) == 0 {
+				traceLogger.Info("no matching pods found for key, cutting search", "key", key)
+				return podsPerKey, nil // early stop since prefix-chain breaks here
+			}
+			podsPerKey[key] = filteredPods
 		} else {
 			traceLogger.Info("key not found in index", "key", key)
+			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
 	}
 

--- a/pkg/kvcache/kvblock/cost_aware_memory_test.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory_test.go
@@ -75,8 +75,9 @@ func TestCostAwareIndexSize(t *testing.T) {
 	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
 	require.NoError(t, err)
 
-	// Lookup should only return the last two keys
-	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey1, requestKey2, requestKey3}, nil)
+	// Lookup the surviving key directly so this test verifies cost-based
+	// eviction without depending on prefix-chain early-stop semantics.
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey3}, nil)
 	require.NoError(t, err)
 
 	assert.Len(t, podsPerKey, 1) // Only requestKey3 should be present

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -128,19 +128,27 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 
 			highestHitIdx = idx
 
+			var filteredPods []PodEntry
 			if podIdentifierSet.Len() == 0 {
 				// If no pod identifiers are provided, return all pods
-				podsPerKey[requestKey] = pods.cache.Keys()
+				filteredPods = pods.cache.Keys()
 			} else {
 				// Filter pods based on the provided pod identifiers
 				for _, pod := range pods.cache.Keys() {
 					if podIdentifierSet.Has(pod.PodIdentifier) {
-						podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
+						filteredPods = append(filteredPods, pod)
 					}
 				}
 			}
+
+			if len(filteredPods) == 0 {
+				traceLogger.Info("no matching pods found for key, cutting search", "key", requestKey)
+				return podsPerKey, nil // early stop since prefix-chain breaks here
+			}
+			podsPerKey[requestKey] = filteredPods
 		} else {
 			traceLogger.Info("key not found in index", "key", requestKey)
+			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
 	}
 

--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -72,14 +72,20 @@ func TestInMemoryIndexSize(t *testing.T) {
 	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
 	require.NoError(t, err)
 
-	// Lookup should only return the last two keys
-	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey1, requestKey2, requestKey3}, nil)
+	// Lookup each key directly so this test verifies LRU eviction without
+	// depending on prefix-chain early-stop semantics.
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey2}, nil)
 	require.NoError(t, err)
 
-	assert.Len(t, podsPerKey, 2) // Only key2 and key3 should be present
+	assert.Len(t, podsPerKey, 1)
 	assert.Len(t, podsPerKey[requestKey2], 1)
-	assert.Len(t, podsPerKey[requestKey3], 1)
 	assert.Contains(t, podsPerKey[requestKey2], PodEntry{PodIdentifier: "pod2", DeviceTier: "gpu"})
+
+	podsPerKey, err = index.Lookup(ctx, []BlockHash{requestKey3}, nil)
+	require.NoError(t, err)
+
+	assert.Len(t, podsPerKey, 1)
+	assert.Len(t, podsPerKey[requestKey3], 1)
 	assert.Contains(t, podsPerKey[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
 }
 


### PR DESCRIPTION

## Changes
- Stop `Index.Lookup` at the first break in the prefix chain for `InMemoryIndex` and `CostAwareMemoryIndex`.
- Treat a missing key, an empty pod cache, or a pod filter with no matches as a chain break.
- Add shared coverage for missing-key and filtered-miss cases, and adjust eviction tests to check surviving keys directly.

## Why

KV-cache hits are only useful while the prefix is continuous. If a block in the middle of the chain is missing, later blocks cannot be used even if they still exist in the index.

The previous in-memory lookup behavior skipped over gaps and kept scanning the rest of `requestKeys`. That could overstate a pod's cache locality and give it a higher score than it should receive.

For example:

```text
block 0: pod-target
block 1: pod-other     # pod-target has no hit here, so its chain stops
block 2: pod-target    # not usable without block 1
```

Before this change, a lookup filtered to `pod-target` could still return block 2. After this change, lookup returns only the continuous prefix up to block 0, **matching the prefix-cache semantics and the Redis-backed index behavior.**
