### PR TITLE
fix(tokenizer): use writable cache paths

### DIFF
--- a/services/uds_tokenizer/Dockerfile
+++ b/services/uds_tokenizer/Dockerfile
@@ -49,16 +49,14 @@ COPY utils/ /app/utils/
 COPY tokenizer_service/ /app/tokenizer_service/
 COPY tokenizerpb/ /app/tokenizerpb/
 
-# Create directory for UDS socket
-RUN mkdir -p /tmp/tokenizer && chown 65532:65532 /tmp/tokenizer
-
-# Create tokenizer cache directories and set permissions
-ENV TOKENIZERS_DIR=/app/tokenizers
-RUN mkdir -p /app/tokenizers && chown -R 65532:65532 /app/tokenizers
-# Create and set permissions for ModelScope directory
-RUN mkdir -p /.modelscope && chown -R 65532:65532 /.modelscope
-# Create and set permissions for Hugging Face cache directory
-RUN mkdir -p /.cache && chown -R 65532:65532 /.cache
+# Keep runtime caches under /tmp so restricted non-root runtimes can write them.
+ENV HOME=/tmp \
+    XDG_CACHE_HOME=/tmp/.cache \
+    HF_HOME=/tmp/huggingface \
+    VLLM_CACHE_ROOT=/tmp/.cache/vllm \
+    TOKENIZERS_DIR=/tmp/tokenizers
+RUN mkdir -p /tmp/tokenizer /tmp/tokenizers /tmp/.cache/vllm /tmp/huggingface \
+    && chmod 1777 /tmp/tokenizer /tmp/tokenizers /tmp/.cache /tmp/.cache/vllm /tmp/huggingface
 
 # Create non-root user so getpwuid() works (required by torch/vllm)
 RUN useradd -u 65532 -m nonroot

--- a/services/uds_tokenizer/README.md
+++ b/services/uds_tokenizer/README.md
@@ -43,6 +43,9 @@ Before using tokenization methods, initialize the tokenizer for a specific model
 | `PROBE_PORT` | Port for health check endpoint | 8082 |
 | `USE_MODELSCOPE` | Whether to download tokenizer files from ModelScope (true) or Hugging Face (false) | false |
 | `ENABLE_GRPC_REFLECTION` | Enable gRPC server reflection for service discovery | disabled |
+| `TOKENIZERS_DIR` | Directory for downloaded tokenizer files | `/tmp/tokenizers` in the container image |
+| `HF_HOME` | Hugging Face cache directory | `/tmp/huggingface` in the container image |
+| `VLLM_CACHE_ROOT` | vLLM cache directory | `/tmp/.cache/vllm` in the container image |
 
 
 ## gRPC Service Definition
@@ -259,8 +262,8 @@ The service supports:
 - ModelScope models (automatically downloaded and cached)
 - Custom models in standard format
 
-Tokenizers are automatically downloaded and cached in the `tokenizers/` directory.
-The cache directory can be overridden by setting the `TOKENIZERS_DIR` environment variable.
+Tokenizers are automatically downloaded and cached in the directory configured by `TOKENIZERS_DIR`.
+When `TOKENIZERS_DIR` is unset, local source checkouts use the `tokenizers/` directory; the container image sets `TOKENIZERS_DIR=/tmp/tokenizers` so Kubernetes runtimes can write the cache without requiring root-owned paths.
 The source for downloading can be controlled with the `USE_MODELSCOPE` environment variable:
 - `false` (default): Download from Hugging Face
 - `true`: Download from ModelScope
@@ -287,6 +290,6 @@ See [tokenizers/README.md](tokenizers/README.md) for detailed information about 
 │   ├── __init__.py
 │   ├── conftest.py              # Shared fixtures (in-process gRPC server)
 │   ├── test_integration.py      # Integration tests (pytest)
-├── tokenizers/              # Tokenizer files (downloaded automatically)
+├── tokenizers/              # Default tokenizer cache for local source checkouts
 └── README.md                # This file
 ```

--- a/services/uds_tokenizer/tokenizers/README.md
+++ b/services/uds_tokenizer/tokenizers/README.md
@@ -1,10 +1,12 @@
 # Model Caching in Tokenizer Service
 
-The UDS tokenizer service implements an caching mechanism to improve performance and reduce network dependencies. When a model is requested, the service follows this priority order:
+The UDS tokenizer service implements a caching mechanism to improve performance and reduce network dependencies. When a model is requested, the service follows this priority order:
 
-1. **Local Cache**: Check if the model files already exist in the `tokenizers/` directory (configurable via `TOKENIZERS_DIR` env var)
+1. **Local Cache**: Check if the model files already exist in the directory configured by `TOKENIZERS_DIR`
 2. **Remote Download**: If not cached, download from ModelScope or Hugging Face (based on `USE_MODELSCOPE` environment variable)
-3. **Local Storage**: Save downloaded files to the `tokenizers/` directory for future use
+3. **Local Storage**: Save downloaded files to the configured tokenizer cache directory for future use
+
+When `TOKENIZERS_DIR` is unset, local source checkouts default to the `tokenizers/` directory shown below. The container image sets `TOKENIZERS_DIR=/tmp/tokenizers` so restricted Kubernetes runtimes can write the cache.
 
 ## Directory Structure
 
@@ -121,7 +123,7 @@ spec:
         image: your-tokenizer-service:latest
         volumeMounts:
         - name: model-cache
-          mountPath: /app/tokenizers
+          mountPath: /tmp/tokenizers
       volumes:
       - name: model-cache
         persistentVolumeClaim:

--- a/vllm-setup-helm/templates/kv-cache-manager.yaml
+++ b/vllm-setup-helm/templates/kv-cache-manager.yaml
@@ -102,6 +102,16 @@ spec:
           env:
             - name: MODEL
               value: {{ .Values.vllm.model.name | quote }}
+            - name: HOME
+              value: /tmp
+            - name: XDG_CACHE_HOME
+              value: /tmp/.cache
+            - name: HF_HOME
+              value: /tmp/huggingface
+            - name: VLLM_CACHE_ROOT
+              value: /tmp/.cache/vllm
+            - name: TOKENIZERS_DIR
+              value: /tmp/tokenizers
           resources:
             {{- toYaml .Values.kvCacheManager.externalTokenizer.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
## Summary
- keep UDS tokenizer runtime cache defaults under `/tmp` in the container image
- set the same writable cache/home env vars on the Helm `tokenizer-uds` sidecar
- document the container image cache env defaults

Fixes #565

## Testing
- `git diff --check HEAD~1..HEAD`
- Not run: `helm template test vllm-setup-helm --namespace test-ns` (`helm` is not installed locally)
