### PR TITLE
fix(pvc_evictor): restart crawler processes on unexpected death

### DIFF
--- a/kv_connectors/pvc_evictor/evictor.py
+++ b/kv_connectors/pvc_evictor/evictor.py
@@ -346,6 +346,32 @@ class PVCEvictor:
                         )
                         folder_cleaner_process_obj.start()
 
+                    # Check and restart crawler processes
+                    for i, crawler_proc in enumerate(crawler_processes):
+                        if not crawler_proc.is_alive():
+                            hex_range = hex_ranges[i]
+                            self.logger.error(
+                                f"Crawler P{i + 1} died (exitcode={crawler_proc.exitcode}), "
+                                f"restarting (hex %16 in [{hex_range[0]}, {hex_range[1]}])..."
+                            )
+                            crawler_processes[i] = multiprocessing.Process(
+                                target=crawler_process,
+                                args=(
+                                    i,
+                                    hex_range,
+                                    cache_path,
+                                    self.config_dict,
+                                    self.deletion_event,
+                                    self.deletion_queue,
+                                    self.result_queue,
+                                    self.shutdown_event,
+                                    self.folder_queue,
+                                ),
+                                name=f"Crawler-P{i + 1}",
+                            )
+                            crawler_processes[i].start()
+                            self.logger.info(f"Restarted crawler P{i + 1}")
+
                     time.sleep(1.0)
 
         except KeyboardInterrupt:


### PR DESCRIPTION
## Purpose

The main monitoring loop in `evictor.py` checked and restarted activator,
deleter, and folder_cleaner processes when they died unexpectedly, but did
not check crawler processes. If a crawler crashed (OOM, segfault), its
assigned hex range would permanently stop being scanned, causing cold files
in that range to accumulate and eventually fill the disk.

With the default 8 crawlers, a single crawler death means 12.5% of files
are no longer scanned. Multiple crawler deaths accelerate disk fill.

**Changes:**
- `kv_connectors/pvc_evictor/evictor.py`: Add crawler process alive check
  and restart logic to the `except Exception:` monitoring block, following
  the same pattern as the existing activator/deleter/folder_cleaner restart
  code. Logs crawler death with exit code and hex range for diagnostics.

## Test Plan

- [x] Run existing test suite: `cd kv_connectors/pvc_evictor && python3 -m pytest tests/ -v`
- [ ] Manual: kill a crawler process during runtime and verify it restarts via logs

## Test Result

```
41 passed in 0.12s
```