### PR TITLE
feat(tier-normalization): normalize device tier names and default unknown tier weight to 0

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,7 +294,7 @@ Configures the HuggingFace tokenizer backend for downloading tokenizers from Hug
 
 ### KV Cache Backend Configuration (`KVCacheBackendConfig`)
 
-Configures the available device backends which store the KV Cache blocks. This will be used in scoring. 
+Configures the available device backends which store the KV Cache blocks. This will be used in scoring.
 
 ```json
 {
@@ -310,6 +310,24 @@ Configures the available device backends which store the KV Cache blocks. This w
   ]
 }
 ```
+
+**Note**: Device tiers not listed in this configuration default to weight `0` and will not contribute to pod scores. A warning is logged on first encounter of an unknown tier. To include additional tiers (e.g., `fs`, `obj`) in routing decisions, add them to this configuration with appropriate weights.
+
+### Tier Aliases (`tierAliases`)
+
+Different components may use different names for the same physical storage tier. The `tierAliases` configuration maps these alternative names to a canonical name so that store/remove events build equal `PodEntry` records and match correctly during eviction.
+
+```json
+{
+  "tierAliases": {
+    "shared_storage": "fs",
+    "object_store": "obj",
+    "my_custom_tier": "fs"
+  }
+}
+```
+
+**Built-in defaults**: `"shared_storage" → "fs"` and `"object_store" → "obj"` are pre-configured. User-provided aliases merge with and override these defaults.
 
 ## KV-Event Processing Configuration
 
@@ -335,6 +353,7 @@ Configures the ZMQ event processing pool for handling KV cache events. The pool 
 | `engineType` | `string`                                                              | Inference engine adapter type (`"vllm"` or `"sglang"`) | `"vllm"` |
 | `discoverPods` | `boolean`                                                             | Enable Kubernetes pod reconciler for automatic per-pod subscriber management | `true`  |
 | `podDiscoveryConfig` | [PodDiscoveryConfig](#pod-discovery-configuration-podDiscoveryConfig) | Configuration for pod reconciler (only used when `discoverPods` is true) | `null`  |
+| `tierAliases` | `map[string]string`                                                   | Maps alternative medium names to canonical names (e.g., `{"shared_storage": "fs"}`) | built-in defaults |
 
 #### Static Endpoint Mode Example
 

--- a/pkg/kvcache/kvblock_scorer.go
+++ b/pkg/kvcache/kvblock_scorer.go
@@ -19,9 +19,15 @@ package kvcache
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// unknownTierWarned tracks which unknown device tiers have already been warned
+// about, so we don't spam the logs on every block.
+var unknownTierWarned sync.Map
 
 // KVScoringStrategy defines the strategy used to score pods for KV cache block reuse.
 type KVScoringStrategy string
@@ -88,12 +94,21 @@ func (s *LongestPrefixScorer) Strategy() KVScoringStrategy {
 
 // fillMaxWeights populates dst with the maximum weight per podID across all
 // device tiers for the given entries. The caller must clear dst before calling.
-func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWeights map[string]float64) {
+func fillMaxWeights(ctx context.Context, dst map[string]float64, entries []kvblock.PodEntry, mediumWeights map[string]float64) {
+	logger := log.FromContext(ctx)
+
 	for _, entry := range entries {
-		weight := 1.0
+		weight := 0.0 // Default to 0 for unknown tiers
 		if mediumWeights != nil {
 			if w, exists := mediumWeights[entry.DeviceTier]; exists {
 				weight = w
+			} else {
+				// Warn once per unknown tier to avoid log spam
+				if _, loaded := unknownTierWarned.LoadOrStore(entry.DeviceTier, struct{}{}); !loaded {
+					logger.Info("unknown device tier, weight defaults to 0",
+						"tier", entry.DeviceTier,
+						"hint", "add it to KVCacheBackendConfig")
+				}
 			}
 		}
 		if cur, exists := dst[entry.PodIdentifier]; !exists || weight > cur {
@@ -104,7 +119,7 @@ func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWe
 
 // Score implements the longest prefix scoring logic with weighted sum based on BackendConfig.
 func (s *LongestPrefixScorer) Score(
-	_ context.Context,
+	ctx context.Context,
 	keys []kvblock.BlockHash,
 	keyToPods map[kvblock.BlockHash][]kvblock.PodEntry,
 ) (map[string]float64, error) {
@@ -118,7 +133,7 @@ func (s *LongestPrefixScorer) Score(
 	curWeights := make(map[string]float64)
 
 	// Build weight index for the first key in a single pass over entries.
-	fillMaxWeights(curWeights, keyToPods[keys[0]], s.MediumWeights)
+	fillMaxWeights(ctx, curWeights, keyToPods[keys[0]], s.MediumWeights)
 
 	// activePods tracks pods still in the consecutive prefix chain.
 	// Using a plain map and in-place deletion avoids allocating new sets
@@ -136,7 +151,7 @@ func (s *LongestPrefixScorer) Score(
 
 		// Reuse scratch map: clear and refill for current key.
 		clear(curWeights)
-		fillMaxWeights(curWeights, keyToPods[keys[i]], s.MediumWeights)
+		fillMaxWeights(ctx, curWeights, keyToPods[keys[i]], s.MediumWeights)
 
 		// In-place intersection: delete pods from activePods that are not
 		// in the current key, and accumulate scores for those that remain.

--- a/pkg/kvcache/kvblock_scorer_test.go
+++ b/pkg/kvcache/kvblock_scorer_test.go
@@ -106,3 +106,86 @@ func int64KeysToKVBlockKeys(keys []uint64) []kvblock.BlockHash {
 	}
 	return kvKeys
 }
+
+// TestLongestPrefixScorer_UnknownTierDefaultsToZero verifies that unknown device
+// tiers default to weight 0 instead of 1.0, preventing silent score inflation.
+func TestLongestPrefixScorer_UnknownTierDefaultsToZero(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 1.0,
+		"cpu": 0.8,
+	}
+
+	scorer := &kvcache.LongestPrefixScorer{
+		MediumWeights: mediumWeights,
+	}
+	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002, 1003})
+
+	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {
+			{PodIdentifier: podA, DeviceTier: "gpu"},
+			{PodIdentifier: podB, DeviceTier: "fs"}, // unknown tier
+		},
+		1002: {
+			{PodIdentifier: podA, DeviceTier: "cpu"},
+			{PodIdentifier: podB, DeviceTier: "fs"}, // unknown tier
+		},
+		1003: {
+			{PodIdentifier: podB, DeviceTier: "fs"}, // unknown tier
+		},
+	}
+
+	// podA: gpu(1.0) + cpu(0.8) = consecutive prefix match for 2 blocks -> 1.8
+	// podB: fs is unknown -> weight 0 for all blocks -> score 0
+	expected := map[string]float64{
+		podA: 1.8,
+		podB: 0.0,
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	assert.Len(t, scored, 2)
+	for pod, score := range scored {
+		assert.InDelta(t, expected[pod], score, 0.0001,
+			"pod %s: expected %f, got %f", pod, expected[pod], score)
+	}
+}
+
+// TestLongestPrefixScorer_UnknownTierDoesNotInflateScore verifies that an unknown
+// tier doesn't artificially inflate a pod's score above known-tier pods.
+func TestLongestPrefixScorer_UnknownTierDoesNotInflateScore(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu": 1.0,
+		"cpu": 0.8,
+	}
+
+	scorer := &kvcache.LongestPrefixScorer{
+		MediumWeights: mediumWeights,
+	}
+	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002})
+
+	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {
+			{PodIdentifier: "gpu-pod", DeviceTier: "gpu"},
+			{PodIdentifier: "fs-pod", DeviceTier: "fs"}, // unknown tier
+		},
+		1002: {
+			{PodIdentifier: "gpu-pod", DeviceTier: "gpu"},
+			{PodIdentifier: "fs-pod", DeviceTier: "fs"}, // unknown tier
+		},
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+
+	// gpu-pod: 2 blocks × 1.0 = 2.0
+	// fs-pod: 2 blocks × 0 (unknown) = 0
+	expectedGPU := 2.0
+	expectedFS := 0.0
+
+	assert.InDelta(t, expectedGPU, scored["gpu-pod"], 0.0001,
+		"gpu-pod should score 2.0 (2 blocks × 1.0)")
+	assert.InDelta(t, expectedFS, scored["fs-pod"], 0.0001,
+		"fs-pod should score 0 (unknown tier defaults to 0)")
+	assert.Greater(t, scored["gpu-pod"], scored["fs-pod"],
+		"gpu-pod (known tier) should score higher than fs-pod (unknown tier)")
+}

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -140,13 +140,17 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 		cfg = DefaultConfig()
 	}
 
-	// Build tier aliases: start with defaults, then merge user-provided overrides
+	// Build tier aliases: start with defaults, then merge user-provided overrides.
+	// Keys and values are lowercased so normalizeTier can match regardless of
+	// how the user writes them in config.
 	tierAliases := make(map[string]string)
 	for k, v := range defaultTierAliases {
 		tierAliases[k] = v
 	}
 	for k, v := range cfg.TierAliases {
-		tierAliases[k] = v
+		if k != "" && v != "" {
+			tierAliases[strings.ToLower(k)] = strings.ToLower(v)
+		}
 	}
 
 	p := &Pool{

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -34,6 +34,14 @@ const (
 	defaultPodSelector           = "llm-d.ai/inference-serving=true"
 )
 
+// defaultTierAliases maps common medium name variants to canonical names.
+// Different components may use different names for the same physical storage tier.
+// These aliases ensure store/remove events build equal PodEntries and match correctly.
+var defaultTierAliases = map[string]string{
+	"shared_storage": "fs",
+	"object_store":   "obj",
+}
+
 // normalizeDeviceTier lowercases an event's device tier and defaults an empty
 // value to the GPU source tier. Store and remove events that mean the same tier
 // must normalize identically so they build equal PodEntries and dedup scopes;
@@ -43,6 +51,17 @@ func normalizeDeviceTier(deviceTier string) string {
 		return defaultEventSourceDeviceTier
 	}
 	return strings.ToLower(deviceTier)
+}
+
+// normalizeTier applies the Pool's tier alias mapping to a device tier string.
+// It first lowercases the tier, defaults empty to the GPU source tier, then
+// looks up any configured alias.
+func (p *Pool) normalizeTier(deviceTier string) string {
+	tier := normalizeDeviceTier(deviceTier) // handles empty → "gpu" and lowercase
+	if canonical, ok := p.tierAliases[tier]; ok {
+		return canonical
+	}
+	return tier
 }
 
 // Config holds the configuration for the event processing pool.
@@ -63,6 +82,11 @@ type Config struct {
 	// PodDiscoveryConfig holds the configuration for pod discovery.
 	// Only used when DiscoverPods is true.
 	PodDiscoveryConfig *PodDiscoveryConfig `json:"podDiscoveryConfig,omitempty"`
+
+	// TierAliases maps alternative medium names to a canonical name.
+	// Example: {"shared_storage": "fs", "object_store": "obj"}
+	// Applied in processEventBatch before constructing PodEntry.
+	TierAliases map[string]string `json:"tierAliases,omitempty"`
 }
 
 // PodDiscoveryConfig holds configuration for the Kubernetes pod reconciler.
@@ -108,6 +132,7 @@ type Pool struct {
 	tokenProcessor kvblock.TokenProcessor
 	adapter        EngineAdapter
 	groupCatalog   *kvblock.GroupCatalog
+	tierAliases    map[string]string
 	// dedup lives in the Pool, not as an Index decorator, because its scope is
 	// built from event fields absent from the Index.Evict signature (device
 	// tier, KV-cache group, DP rank) and a store must be counted only after
@@ -126,6 +151,15 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 		cfg = DefaultConfig()
 	}
 
+	// Build tier aliases: start with defaults, then merge user-provided overrides
+	tierAliases := make(map[string]string)
+	for k, v := range defaultTierAliases {
+		tierAliases[k] = v
+	}
+	for k, v := range cfg.TierAliases {
+		tierAliases[k] = v
+	}
+
 	p := &Pool{
 		queues:         make([]workqueue.TypedRateLimitingInterface[*RawMessage], cfg.Concurrency),
 		concurrency:    cfg.Concurrency,
@@ -133,6 +167,7 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 		tokenProcessor: tokenProcessor,
 		adapter:        adapter,
 		groupCatalog:   kvblock.NewGroupCatalog(),
+		tierAliases:    tierAliases,
 		dedup:          newEventDedupFilter(),
 	}
 
@@ -336,7 +371,8 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 	for _, genericEvent := range batch.Events {
 		switch ev := genericEvent.(type) {
 		case *BlockStoredEvent:
-			deviceTier := normalizeDeviceTier(ev.DeviceTier)
+			// Normalize tier: lowercase + alias mapping (e.g. "SHARED_STORAGE" → "fs")
+			deviceTier := p.normalizeTier(ev.DeviceTier)
 
 			// Scope for reference-counting this store against duplicate removes.
 			// Mirrors the index eviction identity (pod, tier, group); DP rank is
@@ -460,7 +496,8 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 			p.dedup.trackStore(storeScope, ev.BlockHashes)
 
 		case *BlockRemovedEvent:
-			deviceTier := normalizeDeviceTier(ev.DeviceTier)
+			// Normalize tier: lowercase + alias mapping (e.g. "SHARED_STORAGE" → "fs")
+			deviceTier := p.normalizeTier(ev.DeviceTier)
 
 			// Create PodEntry for this specific event's device tier.
 			podEntries := []kvblock.PodEntry{{PodIdentifier: podIdentifier, DeviceTier: deviceTier}}

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -53,17 +53,6 @@ func normalizeDeviceTier(deviceTier string) string {
 	return strings.ToLower(deviceTier)
 }
 
-// normalizeTier applies the Pool's tier alias mapping to a device tier string.
-// It first lowercases the tier, defaults empty to the GPU source tier, then
-// looks up any configured alias.
-func (p *Pool) normalizeTier(deviceTier string) string {
-	tier := normalizeDeviceTier(deviceTier) // handles empty → "gpu" and lowercase
-	if canonical, ok := p.tierAliases[tier]; ok {
-		return canonical
-	}
-	return tier
-}
-
 // Config holds the configuration for the event processing pool.
 type Config struct {
 	// ZMQEndpoint is the ZMQ address to connect to (e.g., "tcp://indexer:5557").
@@ -181,6 +170,17 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 // GroupCatalog returns the KV cache group metadata learned from events.
 func (p *Pool) GroupCatalog() *kvblock.GroupCatalog {
 	return p.groupCatalog
+}
+
+// normalizeTier applies the Pool's tier alias mapping to a device tier string.
+// It first lowercases the tier, defaults empty to the GPU source tier, then
+// looks up any configured alias.
+func (p *Pool) normalizeTier(deviceTier string) string {
+	tier := normalizeDeviceTier(deviceTier) // handles empty → "gpu" and lowercase
+	if canonical, ok := p.tierAliases[tier]; ok {
+		return canonical
+	}
+	return tier
 }
 
 // Start begins the worker pool.

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -1147,17 +1147,40 @@ func TestTierAliasNormalization(t *testing.T) {
 		},
 	}
 
+	// Step 1: Store with "FS" → normalizes to "fs"
 	pool.processEventBatch(ctx, fsFromVLLM, "pod-1", "test-model")
-	// This remove should match the store entry because both normalize to "fs"
+
+	// Verify: both engine keys have pod-1@fs entry
+	canonicalKeys, err := tp.TokensToKVBlockKeys(kvblock.EmptyBlockHash, makeTokens(16), "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, canonicalKeys, 1)
+
+	result, err := idx.Lookup(ctx, canonicalKeys, nil)
+	require.NoError(t, err)
+	require.Len(t, result[canonicalKeys[0]], 1)
+	assert.Equal(t, "fs", result[canonicalKeys[0]][0].DeviceTier)
+	assert.Equal(t, "pod-1", result[canonicalKeys[0]][0].PodIdentifier)
+
+	// Step 2: Remove with "SHARED_STORAGE" → normalizes to "fs", should match the store entry
 	pool.processEventBatch(ctx, fsFromEvictor, "pod-1", "test-model")
 
-	// Verify the keys were evicted (not stale)
-	for _, hash := range []uint64{100, 101} {
-		reqKey, err := idx.GetRequestKey(ctx, kvblock.BlockHash(hash))
-		// After eviction, the engine key should no longer resolve to a request key
-		// (or the request key should no longer have pod entries)
-		_ = reqKey // The exact behavior depends on index implementation
-		_ = err
+	// Verify: the PodEntry is evicted (engine key no longer resolves, or no pods remain)
+	result, err = idx.Lookup(ctx, canonicalKeys, nil)
+	require.NoError(t, err)
+	// After eviction, the engine→request mapping may still exist but no pods should remain
+	// OR the engine key itself no longer resolves. Either way, the key indicator is:
+	// the PodEntry{pod-1, fs} must be gone.
+	for _, ek := range []uint64{100, 101} {
+		reqKey, err := idx.GetRequestKey(ctx, kvblock.BlockHash(ek))
+		if err != nil || reqKey == kvblock.EmptyBlockHash {
+			// Engine key no longer resolves — entry fully cleaned up
+			continue
+		}
+		// If requestKey still exists, verify no pods remain for it
+		podResult, err := idx.Lookup(ctx, []kvblock.BlockHash{reqKey}, nil)
+		require.NoError(t, err)
+		assert.Empty(t, podResult[reqKey],
+			"PodEntry{pod-1, fs} should be evicted after BlockRemoved with SHARED_STORAGE")
 	}
 }
 

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -1184,10 +1184,9 @@ func TestTierAliasNormalization(t *testing.T) {
 
 // TestNormalizeTierMethod verifies the normalizeTier method applies aliases correctly.
 func TestNormalizeTierMethod(t *testing.T) {
-	cfg := &Config{
-		TierAliases: map[string]string{
-			"custom_tier": "fs",
-		},
+	cfg := DefaultConfig()
+	cfg.TierAliases = map[string]string{
+		"custom_tier": "fs",
 	}
 
 	idx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
@@ -1214,6 +1213,7 @@ func TestNormalizeTierMethod(t *testing.T) {
 		{"GPU", "gpu"}, // No alias, just lowercase
 		{"custom_tier", "fs"},
 		{"CUSTOM_TIER", "fs"}, // lowercase → "custom_tier" → alias → "fs"
+		{"Custom_Tier", "fs"}, // mixed case also normalized
 	}
 
 	for _, tc := range testCases {

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -1165,8 +1165,6 @@ func TestTierAliasNormalization(t *testing.T) {
 	pool.processEventBatch(ctx, fsFromEvictor, "pod-1", "test-model")
 
 	// Verify: the PodEntry is evicted (engine key no longer resolves, or no pods remain)
-	result, err = idx.Lookup(ctx, canonicalKeys, nil)
-	require.NoError(t, err)
 	// After eviction, the engine→request mapping may still exist but no pods should remain
 	// OR the engine key itself no longer resolves. Either way, the key indicator is:
 	// the PodEntry{pod-1, fs} must be gone.

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -1105,3 +1105,100 @@ func counterValue(t *testing.T, c prometheus.Counter) float64 {
 	require.NoError(t, c.Write(&m))
 	return m.GetCounter().GetValue()
 }
+
+// TestTierAliasNormalization verifies that different medium names from vLLM and
+// PVC Evictor normalize to the same canonical tier so they build equal PodEntries.
+func TestTierAliasNormalization(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+
+	// Use default config which includes default tier aliases
+	cfg := DefaultConfig()
+
+	idx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+
+	tp, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
+		BlockSizeTokens: 16,
+		HashSeed:        "test",
+	})
+	require.NoError(t, err)
+
+	pool := NewPool(cfg, idx, tp, nil)
+
+	// vLLM emits medium="FS"
+	fsFromVLLM := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{100, 101},
+				Tokens:      makeTokens(16),
+				ParentHash:  0,
+				DeviceTier:  "FS",
+			},
+		},
+	}
+
+	// PVC Evictor emits medium="SHARED_STORAGE"
+	fsFromEvictor := &EventBatch{
+		Events: []GenericEvent{
+			&BlockRemovedEvent{
+				BlockHashes: []uint64{100, 101},
+				DeviceTier:  "SHARED_STORAGE",
+			},
+		},
+	}
+
+	pool.processEventBatch(ctx, fsFromVLLM, "pod-1", "test-model")
+	// This remove should match the store entry because both normalize to "fs"
+	pool.processEventBatch(ctx, fsFromEvictor, "pod-1", "test-model")
+
+	// Verify the keys were evicted (not stale)
+	for _, hash := range []uint64{100, 101} {
+		reqKey, err := idx.GetRequestKey(ctx, kvblock.BlockHash(hash))
+		// After eviction, the engine key should no longer resolve to a request key
+		// (or the request key should no longer have pod entries)
+		_ = reqKey // The exact behavior depends on index implementation
+		_ = err
+	}
+}
+
+// TestNormalizeTierMethod verifies the normalizeTier method applies aliases correctly.
+func TestNormalizeTierMethod(t *testing.T) {
+	cfg := &Config{
+		TierAliases: map[string]string{
+			"custom_tier": "fs",
+		},
+	}
+
+	idx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+
+	tp, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
+		BlockSizeTokens: 16,
+		HashSeed:        "test",
+	})
+	require.NoError(t, err)
+
+	pool := NewPool(cfg, idx, tp, nil)
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"FS", "fs"},
+		{"fs", "fs"},
+		{"SHARED_STORAGE", "fs"},
+		{"shared_storage", "fs"},
+		{"OBJECT_STORE", "obj"},
+		{"gpu", "gpu"}, // No alias, just lowercase
+		{"GPU", "gpu"}, // No alias, just lowercase
+		{"custom_tier", "fs"},
+		{"CUSTOM_TIER", "fs"}, // lowercase → "custom_tier" → alias → "fs"
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := pool.normalizeTier(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Addresses two problems with device tier handling in the KV cache scorer:

### Problem 1: Unknown tier defaults to weight 1.0 → silently inflates scores

`fillMaxWeights` falls back to `weight = 1.0` for any DeviceTier not in the configured `KVCacheBackendConfig`. With the default config (`gpu=1.0, cpu=0.8`), new tiers introduced by vLLM (e.g. `fs`, `obj`) get the same score as GPU:

| Pod state | Before | After |
|-----------|--------|-------|
| GPU(1.0) + FS(unknown) | max(1.0, 1.0) = 1.0 | max(1.0, 0) = 1.0 ✅ |
| CPU(0.8) + FS(unknown) | max(0.8, **1.0**) = **1.0** ❌ | max(0.8, 0) = 0.8 ✅ |
| Only FS(unknown) | **1.0** ❌ (same as GPU) | **0** + warning ⚠️ |

**Fix**: Default unknown tier weight to `0.0` with a one-time warning per unknown tier. Users must explicitly configure new tiers to participate in routing.

### Problem 2: Tier name mismatch → store/remove don't match

Different components use different names for the same physical tier:

```
vLLM BlockStored:       medium="FS"               → PodEntry{pod, "fs"}
PVC Evictor BlockRemoved: medium="SHARED_STORAGE"  → PodEntry{pod, "shared_storage"}
```

Same physical tier, two different PodEntries. Evict of `"shared_storage"` doesn't match the `"fs"` store entry → stale entries remain.

**Fix**: Added a tier alias registry (`Config.TierAliases`) that normalizes alternative medium names to canonical names before constructing PodEntries. Built-in defaults: `shared_storage → fs`, `object_store → obj`.

## Changes

| File | Description |
|------|-------------|
| `pkg/kvcache/kvblock_scorer.go` | `fillMaxWeights` default 0 + one-time warning per unknown tier |
| `pkg/kvevents/pool.go` | `Config.TierAliases` field, `normalizeTier` method, default aliases |
| `pkg/kvcache/kvblock_scorer_test.go` | Tests for unknown tier weight 0 behavior |
| `pkg/kvevents/pool_test.go` | Tests for tier alias normalization (FS/SHARED_STORAGE → fs) |
| `docs/configuration.md` | Document `tierAliases` config and unknown tier behavior |

## Backward Compatibility

- Existing configs with `gpu` and `cpu` weights are unaffected.
- Unknown tiers change from silent 1.0 → silent 0 + warning. This is safer: pods with only unknown-tier entries become invisible to the router until the user explicitly configures them.
- Built-in aliases (`shared_storage → fs`, `object_store → obj`) are additive; users can override via config.