### PR TITLE
test(kvcache): add regression coverage for empty-BlockHashes MTP panic

### DIFF
--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -222,3 +222,30 @@ func TestAddWithNilEngineKeys(t *testing.T) {
 	_, err = index.GetRequestKey(ctx, requestKey)
 	assert.Error(t, err, "GetRequestKey should fail since no engineKey mapping was created")
 }
+
+// TestAddWithEmptyEngineKeys tests that Add() with a non-nil but zero-length
+// engineKeys slice behaves the same as nil engineKeys (regression test: MTP
+// speculative decoding events carry tokens but no block hashes, and callers
+// build engineKeys via make([]BlockHash, len(ev.BlockHashes)), which yields a
+// non-nil empty slice rather than nil).
+func TestAddWithEmptyEngineKeys(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index := createInMemoryIndexForTesting(t)
+
+	requestKey := BlockHash(66666666)
+	pod := PodEntry{PodIdentifier: "10.0.0.4:8080", Speculative: true}
+
+	// Add with a non-nil, empty engineKeys slice - must not panic.
+	err := index.Add(ctx, []BlockHash{}, []BlockHash{requestKey}, []PodEntry{pod})
+	require.NoError(t, err)
+
+	// Lookup by requestKey should work
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey}, nil)
+	require.NoError(t, err)
+	assert.Len(t, podsPerKey[requestKey], 1)
+	assert.Contains(t, podsPerKey[requestKey], pod)
+
+	// GetRequestKey should NOT find a mapping (no engineKey was stored)
+	_, err = index.GetRequestKey(ctx, requestKey)
+	assert.Error(t, err, "GetRequestKey should fail since no engineKey mapping was created")
+}

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -554,6 +554,42 @@ func TestBlockStoredEvent_OffloadingEmptyTokens(t *testing.T) {
 	}
 }
 
+// TestBlockStoredEvent_MTPEmptyBlockHashes verifies that a BlockStoredEvent
+// carrying tokens but an empty BlockHashes list (as emitted by vLLM MTP
+// speculative decoding) is processed without panicking and falls back to a
+// request-key-only (speculative) index entry, matching the nil-engineKeys
+// behavior documented on InMemoryIndex.Add.
+func TestBlockStoredEvent_MTPEmptyBlockHashes(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tp := newTestPool(t, 16)
+
+	tokens := makeTokens(16)
+
+	batch := &EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{},
+				Tokens:      tokens,
+				ParentHash:  0,
+			},
+		},
+	}
+	require.NotPanics(t, func() {
+		pool.processEventBatch(ctx, batch, "pod-mtp", "test-model")
+	})
+
+	canonicalKeys, err := tp.TokensToKVBlockKeys(
+		kvblock.EmptyBlockHash, tokens, "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, canonicalKeys, 1)
+
+	// Request-key -> pod mapping should exist even though no engine keys were provided.
+	result, err := idx.Lookup(ctx, canonicalKeys, nil)
+	require.NoError(t, err)
+	require.Len(t, result[canonicalKeys[0]], 1)
+	assert.Equal(t, "pod-mtp", result[canonicalKeys[0]][0].PodIdentifier)
+}
+
 // TestBlockStoredEvent_OffloadingUnknownEngineKeys verifies that an offloading
 // event with engine keys not yet in the index is a graceful no-op.
 func TestBlockStoredEvent_OffloadingUnknownEngineKeys(t *testing.T) {


### PR DESCRIPTION
The InMemoryIndex.Add index-out-of-range panic on empty (non-nil) engineKeys with non-empty requestKeys was already fixed by #670 via the shared engineToRequestMapping() length guard, but no test exercised Add() or Pool.processEventBatch() with the exact non-nil-empty-slice shape produced for BlockStored events without block hashes (e.g. vLLM MTP speculative decoding).

Add TestAddWithEmptyEngineKeys and TestBlockStoredEvent_MTPEmptyBlockHashes to lock in that behavior.

Co-Authored-By: Claude

Fixes #699 