### PR TITLE
fix(telemetry): support OTEL_TRACES_EXPORTER=none in InitTracing

### DIFF
--- a/pkg/telemetry/tracing.go
+++ b/pkg/telemetry/tracing.go
@@ -65,7 +65,7 @@ func stripScheme(endpoint string) string {
 // InitTracing initializes OpenTelemetry tracing.
 // Configuration is done via environment variables:
 // - OTEL_SERVICE_NAME: Service name (default: llm-d-kv-cache)
-// - OTEL_TRACES_EXPORTER: Span exporter, "otlp" or "console" (default: otlp)
+// - OTEL_TRACES_EXPORTER: Span exporter, "otlp", "console" or "none" (default: otlp)
 // - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP collector endpoint (default: http://localhost:4317)
 // - OTEL_TRACES_SAMPLER: Sampling strategy (default: parentbased_traceidratio)
 // - OTEL_TRACES_SAMPLER_ARG: Sampling ratio (default: 0.1 for 10%).
@@ -94,15 +94,13 @@ func InitTracing(ctx context.Context) (func(context.Context) error, error) {
 		}
 	}
 
+	exporterType := traceExporterType(logger)
+
 	logger.Info("Initializing OpenTelemetry tracing",
 		"endpoint", endpoint,
 		"service", serviceName,
+		"exporter", exporterType,
 		"samplingRatio", samplingRatio)
-
-	exporter, err := newSpanExporter(ctx, endpoint, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
-	}
 
 	// Create resource with service name and build version
 	res, err := resource.New(ctx,
@@ -115,12 +113,23 @@ func InitTracing(ctx context.Context) (func(context.Context) error, error) {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	// Create trace provider with parent-based sampling
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
+	opt := []sdktrace.TracerProviderOption{
 		sdktrace.WithResource(res),
 		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(samplingRatio))),
-	)
+	}
+
+	// "none" registers no span processor at all. Spans are still created and
+	// propagated, so instrumented code and context propagation are unaffected.
+	if exporterType != exporterTypeNone {
+		exporter, err := newSpanExporter(ctx, exporterType, endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create trace exporter: %w", err)
+		}
+		opt = append(opt, sdktrace.WithBatcher(exporter))
+	}
+
+	// Create trace provider with parent-based sampling
+	tp := sdktrace.NewTracerProvider(opt...)
 
 	// Set global trace provider
 	otel.SetTracerProvider(tp)
@@ -158,21 +167,45 @@ func Tracer(scope ...string) trace.Tracer {
 	)
 }
 
-// newSpanExporter creates a span exporter selected by OTEL_TRACES_EXPORTER.
-// Supported values are "otlp" (default) and "console"; unknown values fall back
-// to otlp.
-func newSpanExporter(ctx context.Context, endpoint string, logger logr.Logger) (sdktrace.SpanExporter, error) {
+// The exporter types OTEL_TRACES_EXPORTER selects between.
+const (
+	exporterTypeOTLP    = "otlp"
+	exporterTypeConsole = "console"
+	exporterTypeNone    = "none"
+
+	defaultExporterType = exporterTypeOTLP
+)
+
+// traceExporterType resolves OTEL_TRACES_EXPORTER to one of the types
+// newSpanExporter builds:
+//
+//   - otlp: export spans through gRPC to an opentelemetry collector
+//   - console: pretty print spans on stdout, for development
+//   - none: create spans but export nothing
+//
+// An unrecognised value falls back to otlp with a logged warning rather than
+// failing startup; the exporter is not worth failing over.
+func traceExporterType(logger logr.Logger) string {
 	exporterType := os.Getenv("OTEL_TRACES_EXPORTER")
 	if exporterType == "" {
-		exporterType = "otlp"
+		return defaultExporterType
 	}
 
 	switch exporterType {
-	case "console":
-		return stdouttrace.New(stdouttrace.WithPrettyPrint())
-	case "otlp":
+	case exporterTypeOTLP, exporterTypeConsole, exporterTypeNone:
+		return exporterType
 	default:
 		logger.Info("Unsupported OTEL_TRACES_EXPORTER, falling back to otlp", "value", exporterType)
+		return defaultExporterType
+	}
+}
+
+// newSpanExporter builds the exporter named by exporterType, which traceExporterType
+// has already narrowed to otlp or console; "none" is handled by the caller and never
+// reaches here.
+func newSpanExporter(ctx context.Context, exporterType, endpoint string) (sdktrace.SpanExporter, error) {
+	if exporterType == exporterTypeConsole {
+		return stdouttrace.New(stdouttrace.WithPrettyPrint())
 	}
 
 	return otlptracegrpc.New(ctx,

--- a/pkg/telemetry/tracing_internal_test.go
+++ b/pkg/telemetry/tracing_internal_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestTraceExporterType(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		set  bool
+		want string
+	}{
+		{name: "unset defaults to otlp", set: false, want: exporterTypeOTLP},
+		{name: "otlp", env: "otlp", set: true, want: exporterTypeOTLP},
+		{name: "console", env: "console", set: true, want: exporterTypeConsole},
+		{name: "none", env: "none", set: true, want: exporterTypeNone},
+		{name: "an unrecognised value falls back to otlp", env: "jaeger", set: true, want: exporterTypeOTLP},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("OTEL_TRACES_EXPORTER", tc.env)
+			}
+
+			got := traceExporterType(logr.Discard())
+			if got != tc.want {
+				t.Errorf("traceExporterType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// newSpanExporter must build exactly the exporter it was asked for. The stdout
+// exporter in particular must not be constructed for the otlp type.
+func TestNewSpanExporter(t *testing.T) {
+	tests := []struct {
+		exporterType string
+		wantType     string
+	}{
+		{exporterType: exporterTypeOTLP, wantType: "*otlptrace.Exporter"},
+		{exporterType: exporterTypeConsole, wantType: "*stdouttrace.Exporter"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.exporterType, func(t *testing.T) {
+			exporter, err := newSpanExporter(context.Background(), tc.exporterType, "localhost:4317")
+			if err != nil {
+				t.Fatalf("newSpanExporter(%q) error = %v", tc.exporterType, err)
+			}
+			t.Cleanup(func() {
+				if err := exporter.Shutdown(context.Background()); err != nil {
+					t.Errorf("exporter.Shutdown() error = %v", err)
+				}
+			})
+
+			if got := fmt.Sprintf("%T", exporter); got != tc.wantType {
+				t.Errorf("newSpanExporter(%q) = %s, want %s", tc.exporterType, got, tc.wantType)
+			}
+		})
+	}
+}
+
+// "none" registers no exporter and InitTracing must not call newSpanExporter for it,
+// so span creation, sampling and propagation stay intact while nothing is exported.
+func TestNoneExporterStillCreatesSpans(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "1")
+
+	shutdown, err := InitTracing(context.Background())
+	if err != nil {
+		t.Fatalf("InitTracing() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown() error = %v", err)
+		}
+	})
+
+	_, span := Tracer().Start(context.Background(), "none-exporter-span")
+	defer span.End()
+
+	if !span.SpanContext().IsValid() {
+		t.Error("span context is not valid, want spans to still be created and propagated")
+	}
+	if !span.SpanContext().IsSampled() {
+		t.Error("span is not sampled, want the sampler to be unaffected by the exporter")
+	}
+}


### PR DESCRIPTION
newSpanExporter in pkg/telemetry/tracing.go only recognized `OTEL_TRACES_EXPORTER=console` explicitly; every other value, including none and any typo, fell through to building the otlp exporter. Setting `OTEL_TRACES_EXPORTER=none` did not disable span export, it silently exported through otlp instead.

`traceExporterType` is a new function that resolves `OTEL_TRACES_EXPORTER` against otlp/console/none, defaulting to otlp when unset and falling back to otlp with a logged warning on an unrecognised value, matching this function's existing log-and-continue style rather than failing startup. 

This aligns pkg/telemetry/tracing.go with the same `OTEL_TRACES_EXPORTER=none|otlp|console` convention already implemented in llm-d-router's pkg/common/observability/tracing package.