### PR TITLE
fix(kvblock): fail fast when Valkey RDMA is requested but unsupported

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,7 +160,7 @@ Configures the Redis-backed KV block index implementation.
 |-------|------|-------------|---------|
 | `address` | `string` | Redis server address (can include auth: `redis://user:pass@host:port/db`) | `"redis://127.0.0.1:6379"` |
 | `backendType` | `string` | Backend type: "redis" or "valkey" (optional, mainly for documentation) | `"redis"` |
-| `enableRDMA` | `boolean` | Enable RDMA transport for Valkey (experimental, requires Valkey with RDMA support) | `false` |
+| `enableRDMA` | `boolean` | Enable RDMA transport for Valkey (not yet implemented in the Go client — setting `true` makes index creation fail fast rather than silently falling back to TCP) | `false` |
 
 ### Valkey Index Configuration (`RedisIndexConfig`) 
 
@@ -178,7 +178,7 @@ Configures the Valkey-backed KV block index implementation. Valkey is a Redis-co
 |-------|------|-------------|---------|
 | `address` | `string` | Valkey server address. Supports `valkey://`, `valkeys://` (SSL), `redis://`, or plain address | `"valkey://127.0.0.1:6379"` |
 | `backendType` | `string` | Should be "valkey" for Valkey instances | `"valkey"` |
-| `enableRDMA` | `boolean` | Enable RDMA transport (requires Valkey server with RDMA support) | `false` |
+| `enableRDMA` | `boolean` | Enable RDMA transport (not yet implemented in the Go client — setting `true` makes index creation fail fast rather than silently falling back to TCP) | `false` |
 
 **Note**: Both Redis and Valkey configurations use the same `RedisIndexConfig` structure since Valkey is API-compatible with Redis.
 

--- a/examples/valkey_configuration.md
+++ b/examples/valkey_configuration.md
@@ -20,6 +20,11 @@ This example demonstrates how to configure the KV-Cache indexer to use Valkey as
 
 ## Valkey with RDMA Support
 
+> **Not usable yet.** The Go client has no way to actually enable RDMA, so
+> setting `enableRDMA: true` makes the indexer fail to start rather than
+> silently connect over TCP. See [RDMA Configuration Notes](#rdma-configuration-notes)
+> below. This example config will currently error out at startup.
+
 ```json
 {
   "kvBlockIndexConfig": {
@@ -93,8 +98,14 @@ To migrate from Redis to Valkey, simply change the configuration:
 
 ## RDMA Configuration Notes
 
-When `enableRDMA: true` is set:
+`enableRDMA: true` is not currently usable: the Go client has no
+configuration surface to actually enable RDMA, so `NewValkeyIndex` /
+`NewRedisIndex` return an error and refuse to start rather than silently
+connecting over TCP as a substitute. Leave `enableRDMA: false` (the default)
+until Go client support lands.
+
+When RDMA support does become available:
 - Ensure your Valkey server is compiled with RDMA support
 - Verify that RDMA hardware and drivers are properly configured
-- Note that RDMA support in the Go client is experimental
-- The connection will fall back to standard TCP if RDMA is not available
+- It will likely require migrating from `go-redis/redis` to a client that
+  supports RDMA (e.g. `valkey-io/valkey-go`)

--- a/examples/valkey_example/README.md
+++ b/examples/valkey_example/README.md
@@ -45,10 +45,10 @@ VALKEY_ADDR="valkey://your-valkey-server:6379" make run-example valkey
 
 ### With RDMA Support
 
-**Note**: RDMA is currently not supported in the Go client library. The configuration flag is a placeholder for future support. See [RDMA Limitations](#rdma-limitations) for details.
+**Note**: RDMA is currently not supported in the Go client library. The configuration flag is a placeholder for future support. Setting it to `true` will make the indexer refuse to start rather than silently connect over TCP — see [RDMA Limitations](#rdma-limitations) for details.
 
 ```bash
-# This will run but RDMA will not be active (falls back to TCP)
+# This will fail fast at startup: RDMA is not yet implemented in the Go client.
 VALKEY_ADDR="valkey://rdma-valkey-server:6379" \
 VALKEY_ENABLE_RDMA="true" \
 make run-example valkey
@@ -57,7 +57,7 @@ make run-example valkey
 ### Environment Variables
 
 - `VALKEY_ADDR`: Valkey server address (default: `valkey://127.0.0.1:6379`)
-- `VALKEY_ENABLE_RDMA`: Enable RDMA transport flag (default: `false`) - **Note: Currently non-functional, see [RDMA Limitations](#rdma-limitations)**
+- `VALKEY_ENABLE_RDMA`: Enable RDMA transport flag (default: `false`) - **Note: Currently non-functional; setting it to `true` causes startup to fail, see [RDMA Limitations](#rdma-limitations)**
 - `HF_TOKEN`: Hugging Face token for tokenizer access (optional)
 
 ## What the Example Does
@@ -132,10 +132,9 @@ The Valkey backend is API-compatible with Redis, so you can easily switch betwee
 While Valkey server supports RDMA transport for ultra-low latency networking, neither the Go Redis client (`go-redis/redis`) nor the Valkey Go client ([`valkey-io/valkey-go`](https://github.com/valkey-io/valkey-go)) currently expose configuration options to enable RDMA connections. The `enableRDMA` configuration flag in this codebase is a placeholder for future support.
 
 **What happens when you enable RDMA:**
-- The configuration flag is accepted and stored
-- A warning message is logged: "RDMA requested for Valkey but not yet supported in Go client - using TCP"
-- The connection falls back to standard TCP transport
-- All functionality works normally, just without RDMA benefits
+- The configuration flag is accepted, but `NewValkeyIndex` / `NewRedisIndex` return an error and the indexer refuses to start
+- No index is created, and no connection is opened over TCP as a silent substitute
+- This is intentional: since the Go client cannot actually honor RDMA, running anyway would let an operator believe RDMA is active in production when it silently isn't. Set `enableRDMA: false` to run over standard TCP.
 
 **Future Support:**
 When RDMA support becomes available, it will require migrating from `go-redis/redis` to the `valkey-io/valkey-go` client, as Redis does not support RDMA.
@@ -148,7 +147,7 @@ When RDMA support becomes available, it will require migrating from `go-redis/re
 - Verify the address format (supports `valkey://`, `redis://`, or plain addresses)
 
 ### RDMA Issues
-- **Note**: RDMA is not currently supported in Go clients - see [RDMA Limitations](#rdma-limitations)
+- **Note**: RDMA is not currently supported in Go clients - enabling it makes startup fail fast rather than silently falling back to TCP, see [RDMA Limitations](#rdma-limitations)
 - If enabling RDMA in the future: Confirm Valkey server is compiled with RDMA support, verify RDMA hardware and drivers are properly configured, and check that both client and server are on RDMA-enabled networks
 
 ### Performance Issues

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -94,17 +94,24 @@ func NewRedisIndex(config *RedisIndexConfig) (Index, error) {
 		return nil, fmt.Errorf("failed to parse %s URL: %w", config.BackendType, err)
 	}
 
-	// Future: Add RDMA configuration for Valkey when supported
+	// RDMA for Valkey is not yet implemented: the Go client has no
+	// configuration surface to enable it, so honoring EnableRDMA would mean
+	// silently running over plain TCP while the operator believes RDMA is
+	// active in production, with no signal that anything is wrong.
+	//
+	// Note: RDMA will work if configured directly on the Valkey server
+	// instance, but the Go client can't be told to use it yet. This flag is
+	// a placeholder for future Go client RDMA support.
+	//
+	// Fail fast rather than silently degrading, matching how this package
+	// already treats unsupported/invalid configuration elsewhere (e.g.
+	// NewKVBlockScorer's "unsupported scoring strategy" and NewIndex's "no
+	// valid index configuration provided" errors): refuse to start so a
+	// misconfigured RDMA expectation is caught at startup, not discovered
+	// later as an unexplained performance or connectivity gap in production.
 	if config.BackendType == "valkey" && config.EnableRDMA {
-		// TODO: Implement RDMA configuration when Valkey Go client supports it
-		//
-		// Note: RDMA will work if configured directly in the Valkey server instance,
-		// but the Go client doesn't yet have configuration options to enable RDMA.
-		// This configuration flag is a placeholder for future Go client RDMA support.
-		// The connection will work with standard TCP for now.
-
-		// Log that RDMA is requested but not yet supported in Go client
-		fmt.Printf("RDMA requested for Valkey but not yet supported in Go client - using TCP\n")
+		return nil, fmt.Errorf("RDMA requested for %s (EnableRDMA=true) but is not yet supported by the Go client; "+
+			"set EnableRDMA=false to use standard TCP", config.BackendType)
 	}
 
 	redisClient := redis.NewClient(redisOpt)

--- a/pkg/kvcache/kvblock/valkey_test.go
+++ b/pkg/kvcache/kvblock/valkey_test.go
@@ -81,14 +81,14 @@ func TestValkeyIndexConfiguration(t *testing.T) {
 			shouldSucceed:   true,
 		},
 		{
-			name: "valkey with RDMA enabled",
+			name: "valkey with RDMA enabled fails fast (not yet supported by Go client)",
 			config: &RedisIndexConfig{
 				Address:     server.Addr(),
 				BackendType: "valkey",
 				EnableRDMA:  true,
 			},
 			expectedBackend: "valkey",
-			shouldSucceed:   true,
+			shouldSucceed:   false,
 		},
 		{
 			name: "valkey:// URL scheme",
@@ -134,10 +134,6 @@ func TestValkeyIndexConfiguration(t *testing.T) {
 				valkeyIndex, ok := index.(*RedisIndex)
 				require.True(t, ok)
 				assert.Equal(t, tt.expectedBackend, valkeyIndex.BackendType)
-
-				if tt.config != nil && tt.config.EnableRDMA {
-					assert.True(t, valkeyIndex.EnableRDMA)
-				}
 			} else {
 				require.Error(t, err)
 			}


### PR DESCRIPTION
EnableRDMA was accepted and validated as a real config option, but there was no actual RDMA wiring behind it. NewRedisIndex just printed a raw fmt.Printf and silently connected over plain TCP instead, so an operator setting enableRDMA: true in production would believe RDMA was active and be wrong, with nothing surfaced to tell them otherwise.

Make this a hard failure at construction time instead: NewRedisIndex now returns an error when BackendType is "valkey" and EnableRDMA is true, rather than degrading silently. This matches how this package already treats unsupported/invalid configuration elsewhere (NewKVBlockScorer's "unsupported scoring strategy" error, NewIndex's "no valid index configuration provided" error) - constructors here fail closed on config they can't honor rather than logging and continuing.

Also updates the RDMA-enabled test case (it previously asserted success) and the docs/example configs that described the old silent-fallback behavior.

Tested: go build and go vet are clean. Ran the full pkg/kvcache/kvblock test suite, including the updated TestValkeyIndexConfiguration case asserting the new fail-fast behavior; all pass.