### PR TITLE
feat(metrics): enhance cache efficiency metrics

### DIFF
--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -156,6 +156,13 @@ func (m *CostAwareMemoryIndex) MaxCost() int64 {
 	return m.data.MaxCost()
 }
 
+// Size returns the number of request keys currently held in the index.
+func (m *CostAwareMemoryIndex) Size() int {
+	m.keyIndexMu.Lock()
+	defer m.keyIndexMu.Unlock()
+	return len(m.keyIndex)
+}
+
 // CostPodCache wraps a sync.Map of PodEntry and provides cost calculation for memory usage estimation.
 type CostPodCache struct {
 	cache sync.Map // map[PodEntry]struct{}

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -343,6 +343,11 @@ func (m *InMemoryIndex) Clear(ctx context.Context, podIdentifier string) error {
 	return nil
 }
 
+// Size returns the number of request keys currently held in the index.
+func (m *InMemoryIndex) Size() int {
+	return m.data.Len()
+}
+
 // GetRequestKey returns the last request key (highest index in the chain) associated with the given engineKey.
 // This is what Pool uses for parent hash resolution.
 // Returns an error if the engineKey mapping is missing (e.g., already evicted).

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -17,30 +17,65 @@ package kvblock
 import (
 	"context"
 
-	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/metrics"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/metrics"
 )
 
 type instrumentedIndex struct {
 	next Index
+	// backend is the label value identifying the wrapped store backend
+	// (in_memory, redis, valkey, cost_aware_memory).
+	backend string
 }
 
 // NewInstrumentedIndex wraps an Index and emits metrics for Add, Evict, and
-// Lookup.
+// Lookup. It derives the backend label from the wrapped index so that
+// admissions, evictions, hit rate, and entry count are partitioned by store.
 func NewInstrumentedIndex(next Index) Index {
-	return &instrumentedIndex{next: next}
+	return &instrumentedIndex{next: next, backend: backendName(next)}
+}
+
+// sizeReporter is implemented by index backends that can report their current
+// key count cheaply (in O(1)). Redis/Valkey do not implement it, since an
+// accurate count would require a DBSIZE round-trip that also over-counts
+// engine-key mappings.
+type sizeReporter interface {
+	Size() int
+}
+
+// backendName derives the backend label for a raw index implementation.
+// Redis and Valkey share the *RedisIndex type and are distinguished only by
+// its BackendType field, so valkey is labeled separately from redis.
+func backendName(idx Index) string {
+	switch b := idx.(type) {
+	case *InMemoryIndex:
+		return "in_memory"
+	case *RedisIndex:
+		if b.BackendType == "valkey" {
+			return "valkey"
+		}
+		return "redis"
+	case *CostAwareMemoryIndex:
+		return "cost_aware_memory"
+	default:
+		return "unknown"
+	}
 }
 
 func (m *instrumentedIndex) Add(ctx context.Context, engineKeys, requestKeys []BlockHash, entries []PodEntry) error {
 	err := m.next.Add(ctx, engineKeys, requestKeys, entries)
-	metrics.Admissions.Add(float64(len(requestKeys)))
+	metrics.Admissions.WithLabelValues(m.backend).Add(float64(len(requestKeys)))
+	m.updateEntryCount()
 	return err
 }
 
 func (m *instrumentedIndex) Evict(ctx context.Context, key BlockHash, keyType KeyType, entries []PodEntry) error {
 	err := m.next.Evict(ctx, key, keyType, entries)
-	metrics.Evictions.Add(float64(len(entries)))
+	metrics.Evictions.WithLabelValues(m.backend).Add(float64(len(entries)))
+	m.updateEntryCount()
 	return err
 }
 
@@ -59,7 +94,12 @@ func (m *instrumentedIndex) Lookup(
 		return nil, err
 	}
 
-	go recordHitMetrics(pods)
+	// Record the hit metrics and then publish the current entry count and hit
+	// rate together, so the gauge reflects the state after this lookup. Done
+	// inline (rather than via a goroutine) to keep the gauges consistent with
+	// the counters; the result is bounded by the prefix-chain early stop.
+	recordLookupHit(pods)
+	m.updateEntryCount()
 
 	return pods, nil
 }
@@ -69,17 +109,42 @@ func (m *instrumentedIndex) GetRequestKey(ctx context.Context, engineKey BlockHa
 }
 
 func (m *instrumentedIndex) Clear(ctx context.Context, podIdentifier string) error {
-	return m.next.Clear(ctx, podIdentifier)
+	err := m.next.Clear(ctx, podIdentifier)
+	m.updateEntryCount()
+	return err
 }
 
-func recordHitMetrics(keyToPods map[BlockHash][]PodEntry) {
+// updateEntryCount reports the current key count and cumulative hit rate for
+// the backend. Backends that cannot report a cheap, accurate size do not
+// implement sizeReporter, so entry_count is left unset for them.
+func (m *instrumentedIndex) updateEntryCount() {
+	r, ok := m.next.(sizeReporter)
+	if !ok {
+		return
+	}
+	metrics.Entries.WithLabelValues(m.backend).Set(float64(r.Size()))
+
+	var metric dto.Metric
+	hits := 0.0
+	requests := 0.0
+	if err := metrics.LookupHits.Write(&metric); err == nil {
+		hits = metric.GetCounter().GetValue()
+	}
+	metric = dto.Metric{}
+	if err := metrics.LookupRequests.Write(&metric); err == nil {
+		requests = metric.GetCounter().GetValue()
+	}
+	if requests > 0 {
+		metrics.HitRate.WithLabelValues(m.backend).Set(hits / requests)
+	}
+}
+
+// recordLookupHit computes per-pod hit counts from a Lookup result and records
+// the maximum pod hit count and lookup hits.
+func recordLookupHit(keyToPods map[BlockHash][]PodEntry) {
 	podCount := make(map[string]int)
 	for _, pods := range keyToPods {
 		for _, p := range pods {
-			// First time seeing this pod in current lookup window.
-			// set to 1 because counts are local to this call (not cumulative over time).
-			// This ensures compatibility with sliding window attention (SWA) and cache eviction,
-			// where only recent hits within the active window are considered.
 			podCount[p.PodIdentifier]++
 		}
 	}

--- a/pkg/kvcache/kvblock/instrumented_index_test.go
+++ b/pkg/kvcache/kvblock/instrumented_index_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package kvblock_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	. "github.com/llm-d/llm-d-kv-cache/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-kv-cache/pkg/kvcache/metrics"
 )
 
 func createInstrumentedIndexForTesting(t *testing.T) Index {
@@ -45,4 +50,113 @@ func TestNewInstrumentedIndex(t *testing.T) {
 
 func TestInstrumentedIndexBehavior(t *testing.T) {
 	testCommonIndexBehavior(t, createInstrumentedIndexForTesting)
+}
+
+// gaugeValue reads a gauge value via the exported collector, matching on the
+// backend label. The Entries/HitRate gauges are keyed only by backend, so a
+// given backend has a single series.
+func gaugeValue(t *testing.T, c prometheus.Collector, backend string) float64 {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 16)
+	c.Collect(ch)
+	close(ch)
+	for m := range ch {
+		var metric dto.Metric
+		require.NoError(t, m.Write(&metric))
+		if metric.Gauge == nil {
+			continue
+		}
+		for _, l := range metric.Label {
+			if l.GetName() == "backend" && l.GetValue() == backend {
+				return metric.Gauge.GetValue()
+			}
+		}
+	}
+	t.Fatalf("gauge for backend %q not found", backend)
+	return 0
+}
+
+// counterValue reads a single-series (unlabeled) counter value.
+func counterValue(t *testing.T, c prometheus.Metric) float64 {
+	t.Helper()
+	var metric dto.Metric
+	require.NoError(t, c.Write(&metric))
+	return metric.GetCounter().GetValue()
+}
+
+// labeledCounterValue reads a counter series for one backend. A missing series
+// has the same observable value as an uninitialized Prometheus counter: zero.
+func labeledCounterValue(t *testing.T, c prometheus.Collector, backend string) float64 {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 16)
+	c.Collect(ch)
+	close(ch)
+	for m := range ch {
+		var metric dto.Metric
+		require.NoError(t, m.Write(&metric))
+		if metric.Counter == nil {
+			continue
+		}
+		for _, l := range metric.Label {
+			if l.GetName() == "backend" && l.GetValue() == backend {
+				return metric.Counter.GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func TestInstrumentedIndexHitRateAndEntries(t *testing.T) {
+	index, err := NewInMemoryIndex(DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+	instrumented := NewInstrumentedIndex(index)
+
+	ctx := context.Background()
+	key := BlockHash(1)
+	entries := []PodEntry{{PodIdentifier: "pod1"}}
+
+	// After an Add, the entries gauge reflects the number of keys held.
+	require.NoError(t, instrumented.Add(ctx, nil, []BlockHash{key}, entries))
+	require.Equal(t, 1.0, gaugeValue(t, metrics.Entries, "in_memory"))
+
+	// Perform a hit then a miss. LookupHits/LookupRequests are process-global
+	// cumulative counters, so verify hit_rate equals the live hits/requests
+	// ratio rather than assuming a zero baseline.
+	_, err = instrumented.Lookup(ctx, []BlockHash{key}, sets.Set[string]{})
+	require.NoError(t, err)
+	_, err = instrumented.Lookup(ctx, []BlockHash{BlockHash(999)}, sets.Set[string]{})
+	require.NoError(t, err)
+
+	requests := counterValue(t, metrics.LookupRequests)
+	hits := counterValue(t, metrics.LookupHits)
+	require.Greater(t, requests, 0.0)
+	require.InDelta(t, hits/requests, gaugeValue(t, metrics.HitRate, "in_memory"), 1e-9)
+}
+
+func TestInstrumentedIndexBackendLabel(t *testing.T) {
+	// Use the cost-aware-memory backend so this exercises a distinct backend
+	// label (and its Size()) from the in_memory tests above.
+	index, err := NewCostAwareMemoryIndex(&CostAwareMemoryIndexConfig{Size: "1MiB"})
+	require.NoError(t, err)
+	instrumented := NewInstrumentedIndex(index)
+
+	ctx := context.Background()
+	key := BlockHash(7)
+	entry := []PodEntry{{PodIdentifier: "pod1"}}
+	admissionsBefore := labeledCounterValue(t, metrics.Admissions, "cost_aware_memory")
+	evictionsBefore := labeledCounterValue(t, metrics.Evictions, "cost_aware_memory")
+	inMemoryAdmissionsBefore := labeledCounterValue(t, metrics.Admissions, "in_memory")
+	inMemoryEvictionsBefore := labeledCounterValue(t, metrics.Evictions, "in_memory")
+
+	// Add flushes the Ristretto buffer internally, so Size() reflects the new key.
+	require.NoError(t, instrumented.Add(ctx, nil, []BlockHash{key}, entry))
+	require.Equal(t, 1.0, gaugeValue(t, metrics.Entries, "cost_aware_memory"))
+	require.Equal(t, admissionsBefore+1, labeledCounterValue(t, metrics.Admissions, "cost_aware_memory"))
+	require.Equal(t, inMemoryAdmissionsBefore, labeledCounterValue(t, metrics.Admissions, "in_memory"))
+
+	// Eviction empties the index, bringing the entries gauge back to 0.
+	require.NoError(t, instrumented.Evict(ctx, key, RequestKey, entry))
+	require.Equal(t, 0.0, gaugeValue(t, metrics.Entries, "cost_aware_memory"))
+	require.Equal(t, evictionsBefore+1, labeledCounterValue(t, metrics.Evictions, "cost_aware_memory"))
+	require.Equal(t, inMemoryEvictionsBefore, labeledCounterValue(t, metrics.Evictions, "in_memory"))
 }

--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -25,15 +25,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+// backendLabel is the label name used to partition index metrics by the
+// underlying store backend (in_memory, redis, valkey, cost_aware_memory).
+const backendLabel = "backend"
+
 var (
-	Admissions = prometheus.NewCounter(prometheus.CounterOpts{
+	Admissions = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "kvcache", Subsystem: "index", Name: "admissions_total",
 		Help: "Total number of KV-block admissions",
-	})
-	Evictions = prometheus.NewCounter(prometheus.CounterOpts{
+	}, []string{backendLabel})
+	Evictions = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "kvcache", Subsystem: "index", Name: "evictions_total",
 		Help: "Total number of KV-block evictions",
-	})
+	}, []string{backendLabel})
 
 	// LookupRequests counts how many Lookup() calls have been made.
 	LookupRequests = prometheus.NewCounter(prometheus.CounterOpts{
@@ -56,6 +60,16 @@ var (
 		Help:    "Latency of Lookup calls in seconds",
 		Buckets: prometheus.DefBuckets,
 	})
+	// HitRate is the cumulative block-level hit ratio (hits / requests).
+	HitRate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "kvcache", Subsystem: "index", Name: "hit_rate",
+		Help: "Cumulative block-level hit ratio (hits / requests) since process start",
+	}, []string{backendLabel})
+	// Entries is the current number of keys held in the index backend.
+	Entries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "kvcache", Subsystem: "index", Name: "entries",
+		Help: "Current number of keys held in the index",
+	}, []string{backendLabel})
 
 	RenderChatTemplateLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "kvcache", Subsystem: "tokenization", Name: "render_chat_template_latency_seconds",
@@ -95,6 +109,7 @@ func Collectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		Admissions, Evictions,
 		LookupRequests, LookupHits, LookupLatency, MaxPodHitCount,
+		HitRate, Entries,
 		RenderChatTemplateLatency, TokenizationLatency, TokenizedTokensCount,
 		DedupRemovedHashesSuppressed, DedupRemovedHashesForwarded,
 	}
@@ -121,22 +136,34 @@ func StartMetricsLogging(ctx context.Context, interval time.Duration) {
 	}()
 }
 
+// collectCounterTotal sums the counter values across all label series of a
+// (possibly labeled) counter collector. It is used by the metrics log beat to
+// report a single total even when the underlying counter is a CounterVec.
+func collectCounterTotal(c prometheus.Collector) float64 {
+	ch := make(chan prometheus.Metric, 16)
+	c.Collect(ch)
+	close(ch)
+
+	var total float64
+	for m := range ch {
+		var metric dto.Metric
+		if err := m.Write(&metric); err != nil {
+			continue
+		}
+		if metric.Counter != nil {
+			total += metric.Counter.GetValue()
+		}
+	}
+	return total
+}
+
 func logMetrics(ctx context.Context) {
 	var m dto.Metric
 
-	err := Admissions.Write(&m)
-	if err != nil {
-		return
-	}
-	admissions := m.GetCounter().GetValue()
+	admissions := collectCounterTotal(Admissions)
+	evictions := collectCounterTotal(Evictions)
 
-	err = Evictions.Write(&m)
-	if err != nil {
-		return
-	}
-	evictions := m.GetCounter().GetValue()
-
-	err = LookupRequests.Write(&m)
+	err := LookupRequests.Write(&m)
 	if err != nil {
 		return
 	}

--- a/pkg/kvcache/metrics/collector_test.go
+++ b/pkg/kvcache/metrics/collector_test.go
@@ -50,6 +50,8 @@ func TestCollectorsIncludesAllMetrics(t *testing.T) {
 		{"LookupHits", LookupHits},
 		{"LookupLatency", LookupLatency},
 		{"MaxPodHitCount", MaxPodHitCount},
+		{"HitRate", HitRate},
+		{"Entries", Entries},
 		{"RenderChatTemplateLatency", RenderChatTemplateLatency},
 		{"TokenizationLatency", TokenizationLatency},
 		{"TokenizedTokensCount", TokenizedTokensCount},
@@ -80,10 +82,10 @@ func TestLogMetrics(t *testing.T) {
 		buf.Reset()
 
 		// Set test values for metrics
-		Admissions.Inc()       // 1 admission
-		Evictions.Add(2)       // 2 evictions
-		LookupRequests.Add(10) // 10 lookups
-		LookupHits.Add(5)      // 5 hits
+		Admissions.WithLabelValues("in_memory").Inc() // 1 admission
+		Evictions.WithLabelValues("in_memory").Add(2) // 2 evictions
+		LookupRequests.Add(10)                        // 10 lookups
+		LookupHits.Add(5)                             // 5 hits
 
 		// Call logMetrics
 		logMetrics(ctx)


### PR DESCRIPTION
Part of https://github.com/llm-d/llm-d-kv-cache/issues/617.

Completes **Sub-issue 3: Cache Efficiency Metrics Enhancement**.

The index previously exposed aggregate admission/eviction counters without backend attribution or explicit cache efficiency gauges. This change adds a `backend` label to the existing counters and introduces `kvcache_index_entries` and `kvcache_index_hit_rate` gauges through the existing metrics registry.

- Distinguish `in_memory`, `cost_aware_memory`, `redis`, and `valkey` backends, with `unknown` for custom index implementations. Metrics logging continues to aggregate admissions and evictions across backend series.
- Report entry counts for the in-memory and cost-aware-memory indexes using inexpensive size queries. Redis/Valkey gauges are not emitted because these backends do not expose an inexpensive, accurate request-key count.
- Update the gauges after index operations and record lookup hit metrics synchronously. The hit-rate gauge uses the existing process-wide cumulative `lookup_hits_total / lookup_requests_total` values; it is not an independently calculated per-backend hit ratio.
- Test collector registration, gauge updates, and isolation of admission/eviction counter series between backends.

Existing counter metric names are preserved; consumers now receive backend-labeled series and can use `sum(...)` to retain aggregate views.

Validation:
- `go test ./pkg/kvcache/metrics ./pkg/kvcache/kvblock`
- `go test -race ./pkg/kvcache/kvblock`
- `git diff --check`
